### PR TITLE
Refaktorerer tester fra FunSpec til BehaviorSpec (BDD)

### DIFF
--- a/src/test/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselListenerTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselListenerTest.kt
@@ -3,7 +3,7 @@ package no.nav.sokos.skattekort.forespoersel
 import java.time.LocalDateTime
 
 import io.kotest.assertions.nondeterministic.eventually
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.time.withConstantNow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -21,7 +21,7 @@ import no.nav.sokos.skattekort.utils.TestUtils.eventuallyConfiguration
 import no.nav.sokos.skattekort.utils.createTestHttpClient
 
 class ForespoerselListenerTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(listOf(MQListener, DbListener, WiremockListener))
 
         val forSystemQueue = ActiveMQQueue("FOR_SYSTEM")
@@ -54,83 +54,101 @@ class ForespoerselListenerTest :
             forespoerselListener.onOppdateringChanged(false)
         }
 
-        test("start() skal opprette JMS context og consumer") {
-            // Må ha withConstantNow pga. hvis denne testen kjører fra 15.12 til 31.12, så vil det bli 2 bestillinger
-            withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
+        Given("listeneren er konfigurert for køene FOR_SYSTEM og FOR_SYSTEM_BOQ") {
+            When("oppdatering slås på") {
                 val fnr = "11111111111"
-                WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk(fnr))
-
-                forespoerselListener.onOppdateringChanged(true)
-
                 val jmsMessage = "OS;2025;$fnr"
-                JmsTestUtil.sendMessage(msg = jmsMessage, queue = forSystemQueue)
 
-                eventually(eventuallyConfiguration) {
-                    DbListener.dataSource.transaction { session ->
-                        ForespoerselRepository.getAllForespoersel(session) shouldNotBeNull {
-                            size shouldBe 1
-                            first().dataMottatt shouldBe jmsMessage
+                Then("skal JMS context og consumer opprettes og meldingen behandles") {
+                    // Må ha withConstantNow pga. hvis denne testen kjører fra 15.12 til 31.12, så vil det bli 2 bestillinger
+                    withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
+                        WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk(fnr))
+
+                        forespoerselListener.onOppdateringChanged(true)
+
+                        JmsTestUtil.sendMessage(msg = jmsMessage, queue = forSystemQueue)
+
+                        eventually(eventuallyConfiguration) {
+                            DbListener.dataSource.transaction { session ->
+                                ForespoerselRepository.getAllForespoersel(session) shouldNotBeNull {
+                                    size shouldBe 1
+                                    first().dataMottatt shouldBe jmsMessage
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            When("listeneren startes og deretter stoppes") {
+                val jmsMessage = "OS;2025;22222222222"
+
+                Then("skal JMS consumer og context lukkes slik at nye meldinger blir liggende i kø") {
+                    forespoerselListener.onOppdateringChanged(true)
+                    forespoerselListener.onOppdateringChanged(false)
+
+                    JmsTestUtil.assertAllQueuesAreEmpty()
+
+                    // Verifiser at listener ikke mottar meldinger etter stop
+                    JmsTestUtil.sendMessage(msg = jmsMessage, queue = forSystemQueue)
+
+                    eventually(eventuallyConfiguration) {
+                        DbListener.dataSource.transaction { session ->
+                            ForespoerselRepository.getAllForespoersel(session) shouldBe emptyList()
+                        }
+                    }
+                    JmsTestUtil.getMessages(forSystemQueue).size shouldBe 1
+                }
+            }
+        }
+
+        Given("listeneren allerede kjører") {
+            When("oppdatering slås på en gang til") {
+                val fnr = "55555555555"
+                val jmsMessage = "OS;2025;$fnr"
+
+                Then("skal det ikke opprettes en ny listener og meldinger skal fortsatt behandles") {
+                    // Må ha withConstantNow pga. hvis denne testen kjører fra 15.12 til 31.12, så vil det bli 2 bestillinger
+                    withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
+                        WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk(fnr))
+
+                        forespoerselListener.onOppdateringChanged(enabled = true)
+
+                        forespoerselListener.onOppdateringChanged(enabled = true)
+
+                        // Listener skal fortsatt være kjørende og mottar meldinger
+                        JmsTestUtil.sendMessage(msg = jmsMessage, queue = forSystemQueue)
+
+                        eventually(eventuallyConfiguration) {
+                            DbListener.dataSource.transaction { session ->
+                                ForespoerselRepository.getAllForespoersel(session).any {
+                                    it.dataMottatt == jmsMessage
+                                } shouldBe true
+                            }
                         }
                     }
                 }
             }
         }
 
-        test("stop() skal lukke JMS consumer og context") {
-            forespoerselListener.onOppdateringChanged(true)
-            forespoerselListener.onOppdateringChanged(false)
+        Given("listeneren allerede er stoppet") {
+            When("oppdatering slås av en gang til") {
+                val jmsMessage = "OS;2025;66666666666"
 
-            JmsTestUtil.assertAllQueuesAreEmpty()
+                Then("skal det ikke skje noe og meldingen skal bli liggende i kø") {
+                    forespoerselListener.onOppdateringChanged(enabled = false)
 
-            // Verifiser at listener ikke mottar meldinger etter stop
-            val jmsMessage = "OS;2025;22222222222"
-            JmsTestUtil.sendMessage(msg = jmsMessage, queue = forSystemQueue)
+                    forespoerselListener.onOppdateringChanged(enabled = false)
 
-            eventually(eventuallyConfiguration) {
-                DbListener.dataSource.transaction { session ->
-                    ForespoerselRepository.getAllForespoersel(session) shouldBe emptyList()
-                }
-            }
-            JmsTestUtil.getMessages(forSystemQueue).size shouldBe 1
-        }
+                    JmsTestUtil.sendMessage(msg = jmsMessage, queue = forSystemQueue)
 
-        test("onOppdateringChanged() skal ikke gjøre noe når enabled er true og listener allerede kjører") {
-            // Må ha withConstantNow pga. hvis denne testen kjører fra 15.12 til 31.12, så vil det bli 2 bestillinger
-            withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
-                val fnr = "55555555555"
-                WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk(fnr))
-
-                forespoerselListener.onOppdateringChanged(enabled = true)
-
-                forespoerselListener.onOppdateringChanged(enabled = true)
-
-                // Listener skal fortsatt være kjørende og mottar meldinger
-                val jmsMessage = "OS;2025;$fnr"
-                JmsTestUtil.sendMessage(msg = jmsMessage, queue = forSystemQueue)
-
-                eventually(eventuallyConfiguration) {
-                    DbListener.dataSource.transaction { session ->
-                        ForespoerselRepository.getAllForespoersel(session).any {
-                            it.dataMottatt == jmsMessage
-                        } shouldBe true
+                    eventually(eventuallyConfiguration) {
+                        DbListener.dataSource.transaction { session ->
+                            ForespoerselRepository.getAllForespoersel(session) shouldBe emptyList()
+                        }
                     }
+                    JmsTestUtil.getMessages(forSystemQueue).size shouldBe 1
                 }
             }
-        }
-
-        test("onOppdateringChanged() skal ikke gjøre noe når enabled er false og listener allerede stoppet") {
-            forespoerselListener.onOppdateringChanged(enabled = false)
-
-            forespoerselListener.onOppdateringChanged(enabled = false)
-
-            val jmsMessage = "OS;2025;66666666666"
-            JmsTestUtil.sendMessage(msg = jmsMessage, queue = forSystemQueue)
-
-            eventually(eventuallyConfiguration) {
-                DbListener.dataSource.transaction { session ->
-                    ForespoerselRepository.getAllForespoersel(session) shouldBe emptyList()
-                }
-            }
-            JmsTestUtil.getMessages(forSystemQueue).size shouldBe 1
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselServiceTest.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch
 import kotlin.time.ExperimentalTime
 
 import io.kotest.assertions.assertSoftly
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.time.withConstantNow
 import io.kotest.matchers.collections.shouldContainAllIgnoringFields
 import io.kotest.matchers.maps.shouldBeEmpty
@@ -34,7 +34,7 @@ import no.nav.sokos.skattekort.utsending.UtsendingRepository
 
 @OptIn(ExperimentalTime::class)
 class ForespoerselServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(DbListener, WiremockListener)
 
         val pdlClientService: PdlClientService by lazy {
@@ -53,270 +53,304 @@ class ForespoerselServiceTest :
             ForespoerselService(DbListener.dataSource, personService, UnleashIntegration())
         }
 
-        test("taImotForespoersel skal parse message fra OS og oppretter forespoersel, abonnement, bestilling og utsending") {
-            withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
-                WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+        Given("en OS-forespørsel med gyldige identifikatorer i PDL") {
+            When("meldingen inneholder ett fødselsnummer") {
                 val osMessage = "OS;2025;01010112345"
 
-                forespoerselService.taImotForespoersel(osMessage)
+                Then("skal forespørsel, abonnement og bestilling opprettes uten utsending") {
+                    withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
+                        WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+                        forespoerselService.taImotForespoersel(osMessage)
 
-                DbListener.dataSource.transaction { tx ->
-                    val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
-                    forespoerselList.size shouldBe 1
-                    val forespoersel = forespoerselList.first()
-                    forespoersel.forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                        DbListener.dataSource.transaction { tx ->
+                            val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
+                            forespoerselList.size shouldBe 1
+                            val forespoersel = forespoerselList.first()
+                            forespoersel.forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
 
-                    val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
-                    abonnementList.size shouldBe 1
-                    val bestillingList = DBTestUtils.getAllBestilling(tx)
-                    bestillingList.size shouldBe 1
-                    val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
-                    utsendingList.size shouldBe 0
+                            val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
+                            abonnementList.size shouldBe 1
+                            val bestillingList = DBTestUtils.getAllBestilling(tx)
+                            bestillingList.size shouldBe 1
+                            val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
+                            utsendingList.size shouldBe 0
 
-                    verifyData(abonnementList, bestillingList, forespoersel)
+                            verifyData(abonnementList, bestillingList, forespoersel)
+                        }
+                    }
                 }
             }
-        }
 
-        test("taImotForespoersel skal parse melding fra OS med flere bestillinger, og opprette forespoersel, abonnement, bestilling og utsending") {
-            withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
-                WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("12345678901", "23456789012"))
+            When("meldingen inneholder flere fødselsnumre") {
                 val osMessage = "OS;2025;12345678901;23456789012;"
-                forespoerselService.taImotForespoersel(osMessage)
 
-                DbListener.dataSource.transaction { tx ->
-                    val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
-                    val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
-                    val bestillingList = DBTestUtils.getAllBestilling(tx)
-                    val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
-                    assertSoftly {
-                        forespoerselList shouldNotBeNull {
-                            size shouldBe 1
-                            shouldContainAllIgnoringFields(
-                                listOf(
-                                    Forespoersel(dataMottatt = "", forsystem = Forsystem.OPPDRAGSSYSTEMET_STOR),
-                                    Forespoersel(dataMottatt = "", forsystem = Forsystem.OPPDRAGSSYSTEMET_STOR),
-                                ),
-                                Forespoersel::id,
-                                Forespoersel::opprettet,
-                                Forespoersel::dataMottatt,
-                            )
-                        }
-                        abonnementList shouldNotBeNull {
-                            size shouldBe 2
-                        }
-                        bestillingList shouldNotBeNull {
-                            size shouldBe 2
-                        }
-                        utsendingList shouldNotBeNull {
-                            size shouldBe 0
+                Then("skal forespørsel, abonnement og bestilling opprettes for begge uten utsending") {
+                    withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
+                        WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("12345678901", "23456789012"))
+                        forespoerselService.taImotForespoersel(osMessage)
+
+                        DbListener.dataSource.transaction { tx ->
+                            val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
+                            val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
+                            val bestillingList = DBTestUtils.getAllBestilling(tx)
+                            val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
+                            assertSoftly {
+                                forespoerselList shouldNotBeNull {
+                                    size shouldBe 1
+                                    shouldContainAllIgnoringFields(
+                                        listOf(
+                                            Forespoersel(dataMottatt = "", forsystem = Forsystem.OPPDRAGSSYSTEMET_STOR),
+                                            Forespoersel(dataMottatt = "", forsystem = Forsystem.OPPDRAGSSYSTEMET_STOR),
+                                        ),
+                                        Forespoersel::id,
+                                        Forespoersel::opprettet,
+                                        Forespoersel::dataMottatt,
+                                    )
+                                }
+                                abonnementList shouldNotBeNull {
+                                    size shouldBe 2
+                                }
+                                bestillingList shouldNotBeNull {
+                                    size shouldBe 2
+                                }
+                                utsendingList shouldNotBeNull {
+                                    size shouldBe 0
+                                }
+                            }
                         }
                     }
                 }
             }
         }
 
-        test("mot slutten av året skal vi også bestille for neste år") {
-            withConstantNow(LocalDateTime.parse("2025-12-20T00:00:00")) {
-                WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+        Given("en OS-forespørsel mottas mot slutten av året") {
+            When("forespørselen gjelder inneværende år") {
                 val osMessage = "OS;2025;01010112345"
-                forespoerselService.taImotForespoersel(osMessage)
 
-                DbListener.dataSource.transaction { tx ->
-                    val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
-                    forespoerselList.size shouldBe 2
-                    forespoerselList.first().forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                Then("skal det også opprettes bestilling og abonnement for neste år") {
+                    withConstantNow(LocalDateTime.parse("2025-12-20T00:00:00")) {
+                        WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+                        forespoerselService.taImotForespoersel(osMessage)
 
-                    val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
-                    abonnementList.size shouldBe 2
-                    abonnementList.first().inntektsaar shouldBe 2025
-                    abonnementList[1].inntektsaar shouldBe 2026
+                        DbListener.dataSource.transaction { tx ->
+                            val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
+                            forespoerselList.size shouldBe 2
+                            forespoerselList.first().forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
 
-                    val bestillingList = DBTestUtils.getAllBestilling(tx)
-                    bestillingList.size shouldBe 2
-                    val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
-                    utsendingList.size shouldBe 0
+                            val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
+                            abonnementList.size shouldBe 2
+                            abonnementList.first().inntektsaar shouldBe 2025
+                            abonnementList[1].inntektsaar shouldBe 2026
+
+                            val bestillingList = DBTestUtils.getAllBestilling(tx)
+                            bestillingList.size shouldBe 2
+                            val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
+                            utsendingList.size shouldBe 0
+                        }
+                    }
                 }
             }
         }
 
-        test("taImotForespoersel skal parse message fra MANUELL og brukerId og oppretter forespoersel, abonnement, bestilling og utsending") {
-            WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
-            val message = "MANUELL;2026;01010112345"
-            val brukerId = "Z123456"
+        Given("en manuell forespørsel med saksbehandler") {
+            When("meldingen mottas med brukerId") {
+                val message = "MANUELL;2026;01010112345"
+                val brukerId = "Z123456"
 
-            forespoerselService.taImotForespoersel(message, Saksbehandler(brukerId))
+                Then("skal forespørsel, abonnement og bestilling opprettes og audit lagres med brukerId") {
+                    WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+                    forespoerselService.taImotForespoersel(message, Saksbehandler(brukerId))
 
-            DbListener.dataSource.transaction { tx ->
-                val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
-                forespoerselList.size shouldBe 1
-                val forespoersel = forespoerselList.first()
-                forespoersel.forsystem shouldBe Forsystem.MANUELL
+                    DbListener.dataSource.transaction { tx ->
+                        val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
+                        forespoerselList.size shouldBe 1
+                        val forespoersel = forespoerselList.first()
+                        forespoersel.forsystem shouldBe Forsystem.MANUELL
 
-                val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
-                abonnementList.size shouldBe 1
-                val bestillingList = DBTestUtils.getAllBestilling(tx)
-                bestillingList.size shouldBe 1
-                val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
-                utsendingList.size shouldBe 0
+                        val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
+                        abonnementList.size shouldBe 1
+                        val bestillingList = DBTestUtils.getAllBestilling(tx)
+                        bestillingList.size shouldBe 1
+                        val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
+                        utsendingList.size shouldBe 0
 
-                verifyData(abonnementList, bestillingList, forespoersel)
+                        verifyData(abonnementList, bestillingList, forespoersel)
 
-                val auditList = AuditRepository.getAuditByPersonId(tx, abonnementList.first().person.id!!)
-                auditList.first().brukerId shouldBe brukerId
+                        val auditList = AuditRepository.getAuditByPersonId(tx, abonnementList.first().person.id!!)
+                        auditList.first().brukerId shouldBe brukerId
+                    }
+                }
             }
         }
 
-        test("taImotForespoersel med samme person og årstall som en tidligere forespoersel, skal det opprette kun en bestilling") {
-            withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
-                WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+        Given("en person allerede har en tidligere forespørsel for samme år") {
+            When("det kommer en ny forespørsel fra et annet forsystem") {
                 val message1 = "OS;2025;01010112345"
                 val message2 = "MANUELL;2025;01010112345"
 
-                forespoerselService.taImotForespoersel(message1)
-                forespoerselService.taImotForespoersel(message2)
+                Then("skal det bare opprettes én bestilling") {
+                    withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
+                        WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+                        forespoerselService.taImotForespoersel(message1)
+                        forespoerselService.taImotForespoersel(message2)
 
-                DbListener.dataSource.transaction { tx ->
-                    val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
-                    forespoerselList.size shouldBe 2
-                    val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
-                    abonnementList.size shouldBe 2
-                    val bestillingList = DBTestUtils.getAllBestilling(tx)
-                    bestillingList.size shouldBe 1
-                    val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
-                    utsendingList.size shouldBe 0
+                        DbListener.dataSource.transaction { tx ->
+                            val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
+                            forespoerselList.size shouldBe 2
+                            val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
+                            abonnementList.size shouldBe 2
+                            val bestillingList = DBTestUtils.getAllBestilling(tx)
+                            bestillingList.size shouldBe 1
+                            val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
+                            utsendingList.size shouldBe 0
 
-                    val auditList = AuditRepository.getAuditByPersonId(tx, abonnementList.first().person.id!!)
-                    auditList[0].tag shouldBe AuditTag.OPPRETTET_PERSON
-                    auditList[1].tag shouldBe AuditTag.MOTTATT_FORESPOERSEL
-                }
-            }
-        }
-
-        test("taImotForespoersel med samme forsystem, person og årstall som en tidligere forespoersel, skal det kun audit logges dersom en utsending ikke er utført") {
-            withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
-                WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
-                val message = "OS;2025;01010112345"
-
-                forespoerselService.taImotForespoersel(message)
-                forespoerselService.taImotForespoersel(message)
-
-                DbListener.dataSource.transaction { tx ->
-                    val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
-                    forespoerselList.size shouldBe 2
-                    val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
-                    abonnementList.size shouldBe 2
-                    val bestillingList = DBTestUtils.getAllBestilling(tx)
-                    bestillingList.size shouldBe 1
-                    val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
-                    utsendingList.size shouldBe 0
-
-                    val auditList = AuditRepository.getAuditByPersonId(tx, abonnementList.first().person.id!!)
-                    auditList[0].tag shouldBe AuditTag.OPPRETTET_PERSON
-                    auditList[1].tag shouldBe AuditTag.MOTTATT_FORESPOERSEL
-                }
-            }
-        }
-
-        test("taImotForespoersel der vi allerede har skattekort skal lage en utsending direkte") {
-            DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
-
-            val message = "OS;2025;01010112345"
-
-            forespoerselService.taImotForespoersel(message)
-
-            DbListener.dataSource.transaction { tx ->
-                val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
-
-                assertSoftly {
-                    utsendingList shouldNotBeNull {
-                        size shouldBe 1
-                        shouldContainAllIgnoringFields(
-                            listOf(
-                                Utsending(UtsendingId(1), Personidentifikator("01010112345"), 2025, Forsystem.OPPDRAGSSYSTEMET),
-                            ),
-                            Utsending::opprettet,
-                        )
-                    }
-                }
-            }
-        }
-
-        test("Skal ta i mot forespørsler fra databasetabell") {
-            DbListener.loadDataSet("database/forespoersler/forespoersel_fra_tabell.sql")
-            WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("19876543210"))
-
-            forespoerselService.cronForespoerselInput()
-            DbListener.dataSource.transaction { tx ->
-                val bestillinger = DBTestUtils.getAllBestilling(tx)
-
-                assertSoftly {
-                    bestillinger shouldNotBeNull {
-                        size shouldBe 1
-                        shouldContainAllIgnoringFields(
-                            listOf(
-                                Bestilling(
-                                    personId = PersonId(1),
-                                    fnr = Personidentifikator("19876543210"),
-                                    inntektsaar = 2025,
-                                ),
-                            ),
-                            Bestilling::id,
-                            Bestilling::bestillingsbatchId,
-                            Bestilling::oppdatert,
-                        )
-                    }
-                }
-            }
-        }
-
-        test("skal ikke kaste en PSQLException: ERROR: duplicate key value violates unique constraint") {
-            withConstantNow(LocalDateTime.parse("2025-12-20T00:00:00")) {
-                WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
-
-                val message = "OS;2025;01010112345"
-                val startLatch = CountDownLatch(1)
-                val completeLatch = CountDownLatch(2)
-                val exceptions = ConcurrentHashMap<String, Exception>()
-
-                val thread1 =
-                    Thread {
-                        try {
-                            startLatch.await()
-                            forespoerselService.taImotForespoersel(message)
-                        } catch (e: Exception) {
-                            exceptions["thread1"] = e
-                        } finally {
-                            completeLatch.countDown()
+                            val auditList = AuditRepository.getAuditByPersonId(tx, abonnementList.first().person.id!!)
+                            auditList[0].tag shouldBe AuditTag.OPPRETTET_PERSON
+                            auditList[1].tag shouldBe AuditTag.MOTTATT_FORESPOERSEL
                         }
                     }
+                }
+            }
 
-                val thread2 =
-                    Thread {
-                        try {
-                            startLatch.await()
-                            forespoerselService.taImotForespoersel(message)
-                        } catch (e: Exception) {
-                            exceptions["thread2"] = e
-                        } finally {
-                            completeLatch.countDown()
+            When("det kommer en ny forespørsel fra samme forsystem uten utført utsending") {
+                val message = "OS;2025;01010112345"
+
+                Then("skal det bare audit-logges og ikke opprettes en ny bestilling") {
+                    withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
+                        WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+                        forespoerselService.taImotForespoersel(message)
+                        forespoerselService.taImotForespoersel(message)
+
+                        DbListener.dataSource.transaction { tx ->
+                            val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
+                            forespoerselList.size shouldBe 2
+                            val abonnementList = AbonnementRepository.getAllAbonnementer(tx)
+                            abonnementList.size shouldBe 2
+                            val bestillingList = DBTestUtils.getAllBestilling(tx)
+                            bestillingList.size shouldBe 1
+                            val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
+                            utsendingList.size shouldBe 0
+
+                            val auditList = AuditRepository.getAuditByPersonId(tx, abonnementList.first().person.id!!)
+                            auditList[0].tag shouldBe AuditTag.OPPRETTET_PERSON
+                            auditList[1].tag shouldBe AuditTag.MOTTATT_FORESPOERSEL
                         }
                     }
+                }
+            }
+        }
 
-                thread1.start()
-                thread2.start()
+        Given("en person allerede har skattekort lagret") {
+            When("det kommer en ny OS-forespørsel") {
+                val message = "OS;2025;01010112345"
 
-                // Signal both threads to start simultaneously
-                startLatch.countDown()
+                Then("skal det lages en utsending direkte") {
+                    DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
+                    forespoerselService.taImotForespoersel(message)
 
-                // Wait for completion
-                completeLatch.await()
+                    DbListener.dataSource.transaction { tx ->
+                        val utsendingList = UtsendingRepository.getAllUtsendinger(tx)
 
-                DbListener.dataSource.transaction { tx ->
-                    val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
+                        assertSoftly {
+                            utsendingList shouldNotBeNull {
+                                size shouldBe 1
+                                shouldContainAllIgnoringFields(
+                                    listOf(
+                                        Utsending(UtsendingId(1), Personidentifikator("01010112345"), 2025, Forsystem.OPPDRAGSSYSTEMET),
+                                    ),
+                                    Utsending::opprettet,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-                    exceptions.shouldBeEmpty()
-                    forespoerselList.size shouldBe 4
+        Given("det finnes forespørsler lagret i databasetabellen") {
+            When("cron-jobben leser inn forespørslene") {
+                Then("skal det opprettes bestilling for radene i tabellen") {
+                    DbListener.loadDataSet("database/forespoersler/forespoersel_fra_tabell.sql")
+                    WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("19876543210"))
+                    forespoerselService.cronForespoerselInput()
+
+                    DbListener.dataSource.transaction { tx ->
+                        val bestillinger = DBTestUtils.getAllBestilling(tx)
+
+                        assertSoftly {
+                            bestillinger shouldNotBeNull {
+                                size shouldBe 1
+                                shouldContainAllIgnoringFields(
+                                    listOf(
+                                        Bestilling(
+                                            personId = PersonId(1),
+                                            fnr = Personidentifikator("19876543210"),
+                                            inntektsaar = 2025,
+                                        ),
+                                    ),
+                                    Bestilling::id,
+                                    Bestilling::bestillingsbatchId,
+                                    Bestilling::oppdatert,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("to like forespørsler behandles samtidig") {
+            When("begge trådene forsøker å opprette samme forespørsel samtidig") {
+                val message = "OS;2025;01010112345"
+
+                Then("skal det ikke kastes duplicate key-feil") {
+                    withConstantNow(LocalDateTime.parse("2025-12-20T00:00:00")) {
+                        WiremockListener.wiremockPDLStub(WiremockListener.generateHentIdenterBolk("01010112345"))
+
+                        val startLatch = CountDownLatch(1)
+                        val completeLatch = CountDownLatch(2)
+                        val exceptions = ConcurrentHashMap<String, Exception>()
+
+                        val thread1 =
+                            Thread {
+                                try {
+                                    startLatch.await()
+                                    forespoerselService.taImotForespoersel(message)
+                                } catch (e: Exception) {
+                                    exceptions["thread1"] = e
+                                } finally {
+                                    completeLatch.countDown()
+                                }
+                            }
+
+                        val thread2 =
+                            Thread {
+                                try {
+                                    startLatch.await()
+                                    forespoerselService.taImotForespoersel(message)
+                                } catch (e: Exception) {
+                                    exceptions["thread2"] = e
+                                } finally {
+                                    completeLatch.countDown()
+                                }
+                            }
+
+                        thread1.start()
+                        thread2.start()
+
+                        // Signal both threads to start simultaneously
+                        startLatch.countDown()
+
+                        // Wait for completion
+                        completeLatch.await()
+
+                        DbListener.dataSource.transaction { tx ->
+                            val forespoerselList = ForespoerselRepository.getAllForespoersel(tx)
+
+                            exceptions.shouldBeEmpty()
+                            forespoerselList.size shouldBe 4
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/no/nav/sokos/skattekort/infrastructure/pdl/PdlClientServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/infrastructure/pdl/PdlClientServiceTest.kt
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.common.ContentTypes
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -16,7 +16,7 @@ import no.nav.sokos.skattekort.utils.TestUtils.readFile
 import no.nav.sokos.skattekort.utils.createTestHttpClient
 
 internal class PdlClientServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(listOf(WiremockListener))
 
         val pdlClientService: PdlClientService by lazy {
@@ -27,82 +27,85 @@ internal class PdlClientServiceTest :
             )
         }
 
-        test("hent identer fra PDL gir respons med identer") {
-
+        Given("en PDL-klient som henter identer i bulk") {
             val identerFunnetOkResponse = readFile("/pdl/hentIdenterBolkOkResponse.json")
-
-            WiremockListener.wiremock.stubFor(
-                WireMock
-                    .post(urlEqualTo("/graphql"))
-                    .willReturn(
-                        aResponse()
-                            .withHeader(HttpHeaders.ContentType, ContentTypes.APPLICATION_JSON)
-                            .withStatus(HttpStatusCode.OK.value)
-                            .withBody(identerFunnetOkResponse),
-                    ),
-            )
-
-            val response = pdlClientService.getIdenterBolk(listOf("12345678912", "01111953488", "40074203226"))
-
-            response.size shouldBe 3
-
-            response["24519539620"]?.size shouldBe 2
-            response["24519539620"]?.get(0)?.historisk shouldBe true
-            response["24519539620"]?.get(1)?.historisk shouldBe false
-            response["24519539620"]?.get(0)?.gruppe shouldBe IdentGruppe.FOLKEREGISTERIDENT
-
-            response["01111953488"]?.size shouldBe 1
-            response["01111953488"]?.get(0)?.historisk shouldBe false
-            response["01111953488"]?.get(0)?.gruppe shouldBe IdentGruppe.FOLKEREGISTERIDENT
-
-            response["40074203226"]?.size shouldBe 1
-            response["40074203226"]?.get(0)?.historisk shouldBe false
-            response["40074203226"]?.get(0)?.gruppe shouldBe IdentGruppe.FOLKEREGISTERIDENT
-        }
-
-        test("hent identer fra PDL med tom array request gir PdlException") {
-
             val identerFunnetFeilResponse = readFile("/pdl/hentIdenterBolkFeilResponse.json")
-
-            WiremockListener.wiremock.stubFor(
-                WireMock
-                    .post(urlEqualTo("/graphql"))
-                    .willReturn(
-                        aResponse()
-                            .withHeader(HttpHeaders.ContentType, ContentTypes.APPLICATION_JSON)
-                            .withStatus(HttpStatusCode.OK.value)
-                            .withBody(identerFunnetFeilResponse),
-                    ),
-            )
-
-            val exception =
-                shouldThrow<PdlException> {
-                    pdlClientService.getIdenterBolk(emptyList())
-                }
-
-            exception.message shouldBe "Message: Ingen identer angitt."
-        }
-
-        test("hent identer fra PDL uten accesstoken returnerer at clienten ikke er autentisert") {
-
             val ikkeAutentisertResponse = readFile("/pdl/ikkeAutentisertResponse.json")
 
-            WiremockListener.wiremock.stubFor(
-                WireMock
-                    .post(urlEqualTo("/graphql"))
-                    .willReturn(
-                        aResponse()
-                            .withHeader(HttpHeaders.ContentType, ContentTypes.APPLICATION_JSON)
-                            .withStatus(HttpStatusCode.OK.value)
-                            .withBody(ikkeAutentisertResponse),
-                    ),
-            )
+            When("PDL svarer med identer") {
+                Then("returneres alle identene med tilhørende metadata") {
+                    WiremockListener.wiremock.stubFor(
+                        WireMock
+                            .post(urlEqualTo("/graphql"))
+                            .willReturn(
+                                aResponse()
+                                    .withHeader(HttpHeaders.ContentType, ContentTypes.APPLICATION_JSON)
+                                    .withStatus(HttpStatusCode.OK.value)
+                                    .withBody(identerFunnetOkResponse),
+                            ),
+                    )
 
-            val exception =
-                shouldThrow<PdlException> {
-                    pdlClientService.getIdenterBolk(listOf("12345678912"))
+                    val response = pdlClientService.getIdenterBolk(listOf("12345678912", "01111953488", "40074203226"))
+
+                    response.size shouldBe 3
+
+                    response["24519539620"]?.size shouldBe 2
+                    response["24519539620"]?.get(0)?.historisk shouldBe true
+                    response["24519539620"]?.get(1)?.historisk shouldBe false
+                    response["24519539620"]?.get(0)?.gruppe shouldBe IdentGruppe.FOLKEREGISTERIDENT
+
+                    response["01111953488"]?.size shouldBe 1
+                    response["01111953488"]?.get(0)?.historisk shouldBe false
+                    response["01111953488"]?.get(0)?.gruppe shouldBe IdentGruppe.FOLKEREGISTERIDENT
+
+                    response["40074203226"]?.size shouldBe 1
+                    response["40074203226"]?.get(0)?.historisk shouldBe false
+                    response["40074203226"]?.get(0)?.gruppe shouldBe IdentGruppe.FOLKEREGISTERIDENT
                 }
+            }
 
-            exception.message shouldBe "Message: Ikke autentisert"
+            When("forespørselen sendes uten identer") {
+                Then("kastes PdlException med valideringsfeilen") {
+                    WiremockListener.wiremock.stubFor(
+                        WireMock
+                            .post(urlEqualTo("/graphql"))
+                            .willReturn(
+                                aResponse()
+                                    .withHeader(HttpHeaders.ContentType, ContentTypes.APPLICATION_JSON)
+                                    .withStatus(HttpStatusCode.OK.value)
+                                    .withBody(identerFunnetFeilResponse),
+                            ),
+                    )
+
+                    val exception =
+                        shouldThrow<PdlException> {
+                            pdlClientService.getIdenterBolk(emptyList())
+                        }
+
+                    exception.message shouldBe "Message: Ingen identer angitt."
+                }
+            }
+
+            When("PDL svarer at klienten ikke er autentisert") {
+                Then("kastes PdlException med autentiseringsfeilen") {
+                    WiremockListener.wiremock.stubFor(
+                        WireMock
+                            .post(urlEqualTo("/graphql"))
+                            .willReturn(
+                                aResponse()
+                                    .withHeader(HttpHeaders.ContentType, ContentTypes.APPLICATION_JSON)
+                                    .withStatus(HttpStatusCode.OK.value)
+                                    .withBody(ikkeAutentisertResponse),
+                            ),
+                    )
+
+                    val exception =
+                        shouldThrow<PdlException> {
+                            pdlClientService.getIdenterBolk(listOf("12345678912"))
+                        }
+
+                    exception.message shouldBe "Message: Ikke autentisert"
+                }
+            }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/infrastructure/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/infrastructure/pdl/PdlServiceTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.json.Json
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpStatusCode
@@ -27,7 +27,7 @@ import no.nav.sokos.skattekort.utils.createTestHttpClient
 import no.nav.tilgangsmaskinen.ProblemDetailResponse
 
 class PdlServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(listOf(WiremockListener))
 
         val messageSlot = slot<AuditLogg>()
@@ -62,7 +62,7 @@ class PdlServiceTest :
             messageSlot.clear()
         }
 
-        test("returns left when access is denied and does not call PDL") {
+        Given("en saksbehandler uten tilgang til personen") {
             val problemDetailResponse =
                 generateProblemDetailResponse(saksbehandler.ident, "12345678910")
                     .copy(
@@ -70,73 +70,89 @@ class PdlServiceTest :
                         begrunnelse = "Du har ikke tilgang til brukere med fortrolig adresse",
                     )
 
-            WiremockListener.wiremockTilgangsmaskinStub(response = Json.encodeToString(problemDetailResponse), HttpStatusCode.Forbidden)
+            When("navn hentes fra PDL") {
+                Then("returneres feilresponsen fra tilgangsmaskinen uten PDL-kall") {
+                    WiremockListener.wiremockTilgangsmaskinStub(response = Json.encodeToString(problemDetailResponse), HttpStatusCode.Forbidden)
 
-            val result = pdlService.getPersonNavn(ident, saksbehandler)
-            WiremockListener.wiremock.verify(0, postRequestedFor(urlEqualTo("/graphql")))
+                    val result = pdlService.getPersonNavn(ident, saksbehandler)
+                    WiremockListener.wiremock.verify(0, postRequestedFor(urlEqualTo("/graphql")))
 
-            result.left shouldBe problemDetailResponse
+                    result.left shouldBe problemDetailResponse
+                }
+            }
         }
 
-        test("returns right with formatted name when middle name is null") {
-            WiremockListener.wiremockTilgangsmaskinStub()
-            WiremockListener.wiremockPDLStub(WiremockListener.generateHentPersonBolk(Pair(ident, Person(listOf(Navn("Ola", null, "Nordmann"))))))
+        Given("en saksbehandler med tilgang til personen") {
+            When("PDL returnerer navn uten mellomnavn") {
+                Then("returneres formatert navn uten mellomnavn") {
+                    WiremockListener.wiremockTilgangsmaskinStub()
+                    WiremockListener.wiremockPDLStub(WiremockListener.generateHentPersonBolk(Pair(ident, Person(listOf(Navn("Ola", null, "Nordmann"))))))
 
-            val result = pdlService.getPersonNavn(ident, saksbehandler)
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
+                    val result = pdlService.getPersonNavn(ident, saksbehandler)
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
 
-            result.get() shouldBe "Ola Nordmann"
-        }
+                    result.get() shouldBe "Ola Nordmann"
+                }
+            }
 
-        test("returns right with formatted name when middle name is present") {
-            WiremockListener.wiremockTilgangsmaskinStub()
-            WiremockListener.wiremockPDLStub(WiremockListener.generateHentPersonBolk(Pair(ident, Person(listOf(Navn("Ola", "mellom", "Nordmann"))))))
+            When("PDL returnerer navn med mellomnavn") {
+                Then("returneres formatert navn med mellomnavn") {
+                    WiremockListener.wiremockTilgangsmaskinStub()
+                    WiremockListener.wiremockPDLStub(WiremockListener.generateHentPersonBolk(Pair(ident, Person(listOf(Navn("Ola", "mellom", "Nordmann"))))))
 
-            val result = pdlService.getPersonNavn(ident, saksbehandler)
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
+                    val result = pdlService.getPersonNavn(ident, saksbehandler)
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
 
-            result.get() shouldBe "Ola mellom Nordmann"
-        }
+                    result.get() shouldBe "Ola mellom Nordmann"
+                }
+            }
 
-        test("returns right with empty string when PDL returns person without any name entries") {
-            WiremockListener.wiremockTilgangsmaskinStub()
-            WiremockListener.wiremockPDLStub(WiremockListener.generateHentPersonBolk(Pair(ident, null)))
+            When("PDL returnerer person uten navneoppføringer") {
+                Then("returneres tom streng") {
+                    WiremockListener.wiremockTilgangsmaskinStub()
+                    WiremockListener.wiremockPDLStub(WiremockListener.generateHentPersonBolk(Pair(ident, null)))
 
-            val result = pdlService.getPersonNavn(ident, saksbehandler)
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
+                    val result = pdlService.getPersonNavn(ident, saksbehandler)
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
 
-            result.get() shouldBe ""
-        }
+                    result.get() shouldBe ""
+                }
+            }
 
-        test("returns right with empty string when PDL response does not contain ident key") {
-            WiremockListener.wiremockTilgangsmaskinStub()
-            WiremockListener.wiremockPDLStub("{}")
+            When("PDL-responsen ikke inneholder ident-nøkkelen") {
+                Then("returneres tom streng") {
+                    WiremockListener.wiremockTilgangsmaskinStub()
+                    WiremockListener.wiremockPDLStub("{}")
 
-            val result = pdlService.getPersonNavn(ident, saksbehandler)
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
+                    val result = pdlService.getPersonNavn(ident, saksbehandler)
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
 
-            result.get() shouldBe ""
-        }
+                    result.get() shouldBe ""
+                }
+            }
 
-        test("always writes audit log before access check and PDL call") {
-            WiremockListener.wiremockTilgangsmaskinStub()
-            WiremockListener.wiremockPDLStub(WiremockListener.generateHentPersonBolk(Pair(ident, Person(listOf(Navn("Ola", null, "Nordmann"))))))
+            When("oppslaget lykkes") {
+                Then("returneres navnet fra PDL og audit-logg skrives") {
+                    WiremockListener.wiremockTilgangsmaskinStub()
+                    WiremockListener.wiremockPDLStub(WiremockListener.generateHentPersonBolk(Pair(ident, Person(listOf(Navn("Ola", null, "Nordmann"))))))
 
-            val result = pdlService.getPersonNavn(ident, saksbehandler)
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
-            WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
+                    val result = pdlService.getPersonNavn(ident, saksbehandler)
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlPathMatching("/api/v1/ccf/kjerne/.*")))
+                    WiremockListener.wiremock.verify(1, postRequestedFor(urlEqualTo("/graphql")))
 
-            verify(exactly = 1) { auditLogger.auditLog(any()) }
+                    result.get() shouldBe "Ola Nordmann"
+                    verify(exactly = 1) { auditLogger.auditLog(any()) }
 
-            result.get() shouldBe "Ola Nordmann"
-            messageSlot.captured shouldNotBeNull {
-                saksbehandler shouldBe saksbehandler
-                fnr shouldBe ident
-                brukerhandling shouldBe "NAV-ansatt har gjort et oppslag på bruker for å hente navn"
+                    messageSlot.captured shouldNotBeNull {
+                        saksbehandler shouldBe saksbehandler
+                        fnr shouldBe ident
+                        brukerhandling shouldBe "NAV-ansatt har gjort et oppslag på bruker for å hente navn"
+                    }
+                }
             }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/infrastructure/skatteetaten/SkatteetatenClientTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/infrastructure/skatteetaten/SkatteetatenClientTest.kt
@@ -2,7 +2,7 @@ package no.nav.sokos.skattekort.infrastructure.skatteetaten
 
 import kotlinx.serialization.json.Json
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -28,9 +28,8 @@ import no.nav.sokos.skattekort.skattekort.Trekkode
 import no.nav.sokos.skattekort.utils.TestUtils.readFile
 
 class SkatteetatenClientTest :
-    FunSpec({
-
-        test("bestillSkattekort") {
+    BehaviorSpec({
+        Given("en skatteetaten-klient som bestiller skattekort") {
             val bestillSkattekortRequest =
                 bestillSkattekortRequest(
                     2025,
@@ -41,63 +40,75 @@ class SkatteetatenClientTest :
                 )
             val skatteetatenClient = setupClient(readFile("/skatteetaten/bestillSkattekort/bestillSkattekortResponse.json"))
 
-            val response = skatteetatenClient.bestillSkattekort(bestillSkattekortRequest)
+            When("bestilling sendes") {
+                Then("returneres dialog- og bestillingsreferanse") {
+                    val response = skatteetatenClient.bestillSkattekort(bestillSkattekortRequest)
 
-            response shouldNotBeNull {
-                dialogreferanse shouldBe "1"
-                bestillingsreferanse shouldBe "TEST8128"
+                    response shouldNotBeNull {
+                        dialogreferanse shouldBe "1"
+                        bestillingsreferanse shouldBe "TEST8128"
+                    }
+                }
             }
         }
 
-        test("should handle ugyldig inntektsaar") {
+        Given("en skatteetaten-klient som mottar ugyldig inntektsår") {
             val skatteetatenClient = setupClient(readFile("/skatteetaten/hentSkattekort/ugyldig_inntektsaar.json"))
 
-            val response = skatteetatenClient.hentSkattekort("BR1234")
+            When("skattekortet hentes") {
+                Then("returneres status for ugyldig inntektsår uten arbeidsgivere") {
+                    val response = skatteetatenClient.hentSkattekort("BR1234")
 
-            response shouldNotBeNull {
-                status shouldBe ResponseStatus.UGYLDIG_INNTEKTSAAR.name
-                arbeidsgiver shouldBe emptyList()
+                    response shouldNotBeNull {
+                        status shouldBe ResponseStatus.UGYLDIG_INNTEKTSAAR.name
+                        arbeidsgiver shouldBe emptyList()
+                    }
+                }
             }
         }
 
-        test("should handle skattekortopplysningerOK") {
+        Given("en skatteetaten-klient som mottar gyldige skattekortopplysninger") {
             val skatteetatenClient = setupClient(readFile("/skatteetaten/hentSkattekort/skattekortopplysningerOK.json"))
 
-            val response = skatteetatenClient.hentSkattekort("BR1234")
+            When("skattekortet hentes") {
+                Then("returneres skattekortopplysninger med forventet struktur") {
+                    val response = skatteetatenClient.hentSkattekort("BR1234")
 
-            response shouldNotBeNull {
-                status shouldBe ResponseStatus.FORESPOERSEL_OK.name
-                arbeidsgiver shouldNotBeNull {
-                    size shouldBe 1
-                    this[0] shouldNotBeNull {
-                        arbeidsgiveridentifikator.organisasjonsnummer shouldBe "312978083"
-                        arbeidstaker.size shouldBe 1
-                        arbeidstaker[0] shouldNotBeNull {
-                            arbeidstakeridentifikator shouldBe "01010112345"
-                            resultatForSkattekort shouldBe ResultatForSkattekort.SkattekortopplysningerOK.value
-                            skattekort.shouldNotBeNull {
-                                skattekortidentifikator shouldBe 54407
-                                forskuddstrekk.size shouldBe 5
-                                forskuddstrekk[0] shouldNotBeNull {
-                                    trekkode shouldBe Trekkode.LOENN_FRA_HOVEDARBEIDSGIVER.value
-                                    trekktabell.shouldNotBeNull {
-                                        tabellnummer shouldBe "8140"
+                    response shouldNotBeNull {
+                        status shouldBe ResponseStatus.FORESPOERSEL_OK.name
+                        arbeidsgiver shouldNotBeNull {
+                            size shouldBe 1
+                            this[0] shouldNotBeNull {
+                                arbeidsgiveridentifikator.organisasjonsnummer shouldBe "312978083"
+                                arbeidstaker.size shouldBe 1
+                                arbeidstaker[0] shouldNotBeNull {
+                                    arbeidstakeridentifikator shouldBe "01010112345"
+                                    resultatForSkattekort shouldBe ResultatForSkattekort.SkattekortopplysningerOK.value
+                                    skattekort.shouldNotBeNull {
+                                        skattekortidentifikator shouldBe 54407
+                                        forskuddstrekk.size shouldBe 5
+                                        forskuddstrekk[0] shouldNotBeNull {
+                                            trekkode shouldBe Trekkode.LOENN_FRA_HOVEDARBEIDSGIVER.value
+                                            trekktabell.shouldNotBeNull {
+                                                tabellnummer shouldBe "8140"
+                                            }
+                                        }
+                                        forskuddstrekk[1] shouldNotBeNull {
+                                            trekkode shouldBe Trekkode.LOENN_FRA_BIARBEIDSGIVER.value
+                                            trekkprosent.shouldNotBeNull {
+                                                prosentsats.toDouble() shouldBe 43.0
+                                            }
+                                        }
+                                        tilleggsopplysning!!.size shouldBe 4
+                                        tilleggsopplysning shouldContainExactly
+                                            listOf(
+                                                "oppholdPaaSvalbard",
+                                                "kildeskattPaaPensjon",
+                                                "oppholdITiltakssone",
+                                                "kildeskattPaaLoenn",
+                                            )
                                     }
                                 }
-                                forskuddstrekk[1] shouldNotBeNull {
-                                    trekkode shouldBe Trekkode.LOENN_FRA_BIARBEIDSGIVER.value
-                                    trekkprosent.shouldNotBeNull {
-                                        prosentsats.toDouble() shouldBe 43.0
-                                    }
-                                }
-                                tilleggsopplysning!!.size shouldBe 4
-                                tilleggsopplysning shouldContainExactly
-                                    listOf(
-                                        "oppholdPaaSvalbard",
-                                        "kildeskattPaaPensjon",
-                                        "oppholdITiltakssone",
-                                        "kildeskattPaaLoenn",
-                                    )
                             }
                         }
                     }

--- a/src/test/kotlin/no/nav/sokos/skattekort/infrastructure/tilgangsmaskin/TilgangsmaskinClientServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/infrastructure/tilgangsmaskin/TilgangsmaskinClientServiceTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.json.Json
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpStatusCode
 
@@ -15,10 +15,11 @@ import no.nav.sokos.skattekort.utils.createTestHttpClient
 import no.nav.tilgangsmaskinen.ProblemDetailResponse
 
 class TilgangsmaskinClientServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(listOf(WiremockListener))
         val ansattId = "Z123456"
         val testUrl = "/api/v1/ccf/kjerne/$ansattId"
+        val foedselsnummer = "12345678910"
 
         val tilgangsmaskinClientService: TilgangsmaskinClientService by lazy {
             TilgangsmaskinClientService(
@@ -28,82 +29,95 @@ class TilgangsmaskinClientServiceTest :
             )
         }
 
-        test("should return statusCode 204 when saksbehandler has access") {
-            WiremockListener.wiremock.stubFor(
-                WireMock
-                    .post(urlEqualTo(testUrl))
-                    .willReturn(
-                        aResponse().withStatus(HttpStatusCode.NoContent.value),
-                    ),
-            )
-
-            val response = tilgangsmaskinClientService.checkSaksbehandlerAccess(ansattId, "12345678910")
-            response shouldBe null
-        }
-
-        test("should return statusCode 403 when AVVIST_FORTROLIG_ADRESSE") {
-            val problemDetailResponse =
-                generateProblemDetailResponse(ansattId, "12345678910")
-                    .copy(
-                        title = ProblemDetailResponse.Title.AVVIST_FORTROLIG_ADRESSE,
-                        begrunnelse = "Du har ikke tilgang til brukere med fortrolig adresse",
+        Given("en tilgangsmaskin-klient som sjekker tilgang for en saksbehandler") {
+            When("saksbehandler har tilgang til brukeren") {
+                Then("returneres ingen problemdetaljer") {
+                    WiremockListener.wiremock.stubFor(
+                        WireMock
+                            .post(urlEqualTo(testUrl))
+                            .willReturn(
+                                aResponse().withStatus(HttpStatusCode.NoContent.value),
+                            ),
                     )
-            WiremockListener.wiremock.stubFor(
-                WireMock
-                    .post(urlEqualTo(testUrl))
-                    .willReturn(
-                        aResponse()
-                            .withStatus(HttpStatusCode.Forbidden.value)
-                            .withHeader("Content-Type", "application/json")
-                            .withBody(Json.encodeToString(problemDetailResponse)),
-                    ),
-            )
 
-            val response = tilgangsmaskinClientService.checkSaksbehandlerAccess(ansattId, "12345678910")
-            response shouldBe problemDetailResponse
-        }
+                    val response = tilgangsmaskinClientService.checkSaksbehandlerAccess(ansattId, foedselsnummer)
+                    response shouldBe null
+                }
+            }
 
-        test("should return statusCode 403 when AVVIST_STRENGT_FORTROLIG_ADRESSE") {
-            val problemDetailResponse =
-                generateProblemDetailResponse(ansattId, "12345678910")
-                    .copy(
-                        title = ProblemDetailResponse.Title.AVVIST_STRENGT_FORTROLIG_ADRESSE,
-                        begrunnelse = "Du har ikke tilgang til brukere med strengt fortrolig adresse",
+            When("tilgangsmaskinen avviser med fortrolig adresse") {
+                val problemDetailResponse =
+                    generateProblemDetailResponse(ansattId, "12345678910")
+                        .copy(
+                            title = ProblemDetailResponse.Title.AVVIST_FORTROLIG_ADRESSE,
+                            begrunnelse = "Du har ikke tilgang til brukere med fortrolig adresse",
+                        )
+
+                Then("returneres problemdetaljene for fortrolig adresse") {
+                    WiremockListener.wiremock.stubFor(
+                        WireMock
+                            .post(urlEqualTo(testUrl))
+                            .willReturn(
+                                aResponse()
+                                    .withStatus(HttpStatusCode.Forbidden.value)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(Json.encodeToString(problemDetailResponse)),
+                            ),
                     )
-            WiremockListener.wiremock.stubFor(
-                WireMock
-                    .post(urlEqualTo(testUrl))
-                    .willReturn(
-                        aResponse()
-                            .withStatus(HttpStatusCode.Forbidden.value)
-                            .withHeader("Content-Type", "application/json")
-                            .withBody(Json.encodeToString(problemDetailResponse)),
-                    ),
-            )
 
-            val response = tilgangsmaskinClientService.checkSaksbehandlerAccess(ansattId, "12345678910")
-            response shouldBe problemDetailResponse
-        }
+                    val response = tilgangsmaskinClientService.checkSaksbehandlerAccess(ansattId, "12345678910")
+                    response shouldBe problemDetailResponse
+                }
+            }
 
-        test("should return statusCode 403 when AVVIST_SKJERMING") {
-            val problemDetailResponse =
-                generateProblemDetailResponse(ansattId, "12345678910")
-                    .copy(
-                        title = ProblemDetailResponse.Title.AVVIST_SKJERMING,
-                        begrunnelse = "Du har ikke tilgang til Nav-ansatte og andre skjermede brukere",
+            When("tilgangsmaskinen avviser med strengt fortrolig adresse") {
+                val problemDetailResponse =
+                    generateProblemDetailResponse(ansattId, "12345678910")
+                        .copy(
+                            title = ProblemDetailResponse.Title.AVVIST_STRENGT_FORTROLIG_ADRESSE,
+                            begrunnelse = "Du har ikke tilgang til brukere med strengt fortrolig adresse",
+                        )
+
+                Then("returneres problemdetaljene for strengt fortrolig adresse") {
+                    WiremockListener.wiremock.stubFor(
+                        WireMock
+                            .post(urlEqualTo(testUrl))
+                            .willReturn(
+                                aResponse()
+                                    .withStatus(HttpStatusCode.Forbidden.value)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(Json.encodeToString(problemDetailResponse)),
+                            ),
                     )
-            WiremockListener.wiremock.stubFor(
-                WireMock
-                    .post(urlEqualTo(testUrl))
-                    .willReturn(
-                        aResponse()
-                            .withStatus(HttpStatusCode.Forbidden.value)
-                            .withHeader("Content-Type", "application/json")
-                            .withBody(Json.encodeToString(problemDetailResponse)),
-                    ),
-            )
 
-            val response = tilgangsmaskinClientService.checkSaksbehandlerAccess(ansattId, "12345678910")
-            response shouldBe problemDetailResponse
+                    val response = tilgangsmaskinClientService.checkSaksbehandlerAccess(ansattId, "12345678910")
+                    response shouldBe problemDetailResponse
+                }
+            }
+
+            When("tilgangsmaskinen avviser med skjerming") {
+                val problemDetailResponse =
+                    generateProblemDetailResponse(ansattId, "12345678910")
+                        .copy(
+                            title = ProblemDetailResponse.Title.AVVIST_SKJERMING,
+                            begrunnelse = "Du har ikke tilgang til Nav-ansatte og andre skjermede brukere",
+                        )
+
+                Then("returneres problemdetaljene for skjerming") {
+                    WiremockListener.wiremock.stubFor(
+                        WireMock
+                            .post(urlEqualTo(testUrl))
+                            .willReturn(
+                                aResponse()
+                                    .withStatus(HttpStatusCode.Forbidden.value)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(Json.encodeToString(problemDetailResponse)),
+                            ),
+                    )
+
+                    val response = tilgangsmaskinClientService.checkSaksbehandlerAccess(ansattId, "12345678910")
+                    response shouldBe problemDetailResponse
+                }
+            }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/person/PersonServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/person/PersonServiceTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.json.Json
 
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldNotContainNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -24,7 +24,7 @@ import no.nav.sokos.skattekort.util.SQLUtils.transaction
 import no.nav.sokos.skattekort.utils.createTestHttpClient
 
 class PersonServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(DbListener, WiremockListener)
 
         val pdlClientService: PdlClientService by lazy {
@@ -39,205 +39,231 @@ class PersonServiceTest :
             PersonService(DbListener.dataSource, pdlClientService)
         }
 
-        test("Skal ikke kaste exception når det kommer inn en tom liste") {
-            val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(emptyList(), AUDIT_SYSTEM)
-            result.size shouldBe 0
-        }
-
-        test("findOrCreatePersonByFnr skal returnere en person som er registrert") {
-            val fnr = "10101000010"
-            DbListener.loadDataSet("database/person/persondata.sql")
-            DbListener.dataSource.transaction { tx ->
-                val (personId, opprettet) =
-                    personService
-                        .findPersonIdOrCreatePersonByFnr(
-                            fnr = Personidentifikator(fnr),
-                            informasjon = "TEST",
-                            brukerId = AUDIT_SYSTEM,
-                            tx = tx,
-                        )
-                personId shouldNotBe null
-                opprettet shouldBe false
-
-                val auditList = AuditRepository.getAuditByPersonId(tx, personId)
-                auditList.size shouldBe 1
-                auditList.first().tag shouldBe AuditTag.OPPRETTET_PERSON
-                auditList.first().informasjon shouldBe "Person 10 opprettet"
-            }
-        }
-
-        test("findOrCreatePersonByFnr skal returnere ny registrert person") {
-            val fnr = "15467834260"
-            DbListener.loadDataSet("database/person/persondata.sql")
-            DbListener.dataSource.transaction { tx ->
-                val (personId, opprettet) =
-                    personService
-                        .findPersonIdOrCreatePersonByFnr(
-                            fnr = Personidentifikator(fnr),
-                            informasjon = "TEST",
-                            brukerId = AUDIT_SYSTEM,
-                            tx = tx,
-                        )
-                personId shouldNotBe null
-                opprettet shouldBe true
-
-                val auditList = AuditRepository.getAuditByPersonId(tx, personId)
-                auditList.size shouldBe 1
-                auditList.first().tag shouldBe AuditTag.OPPRETTET_PERSON
-                auditList.first().informasjon shouldBe "TEST"
-            }
-        }
-
-        test("getPersonIdAndCheckFoedselsnumreIsUpdated skal returnere map med personId for eksisterende personer") {
-            val fnrList = listOf("10101000010", "10101000011", "10101000012")
-            DbListener.loadDataSet("database/person/persondata.sql")
-
-            WiremockListener.wiremockPDLStub(generateHentIdenterBolk(*fnrList.toTypedArray()))
-            val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
-
-            result.size shouldBe 3
-            result.values.forEach { personId ->
-                personId shouldNotBe null
-            }
-        }
-
-        test("getPersonIdAndCheckFoedselsnumreIsUpdated skal opprette nye personer fra PDL") {
-            val fnrList = listOf("15467834260")
-            DbListener.loadDataSet("database/person/persondata.sql")
-
-            WiremockListener.wiremockPDLStub(generateHentIdenterBolk(*fnrList.toTypedArray()))
-            val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
-
-            result.size shouldBe 1
-            result[fnrList[0]] shouldNotBe null
-        }
-
-        test("getPersonIdAndCheckFoedselsnumreIsUpdated skal oppdatere foedselsnummer når PDL returnerer ny ident") {
-            val oldFnr = "10101000098"
-            val newFnr = "10101000099"
-            val fnrList = listOf(oldFnr)
-            DbListener.loadDataSet("database/person/persondata.sql")
-
-            WiremockListener.wiremockPDLStub(
-                Json.encodeToString(
-                    GraphQLResponse(
-                        HentIdenterBolk.Result(
-                            hentIdenterBolk =
-                                listOf(
-                                    HentIdenterBolkResult(
-                                        ident = oldFnr,
-                                        identer =
-                                            listOf(
-                                                IdentInformasjon(newFnr, false, IdentGruppe.FOLKEREGISTERIDENT),
-                                                IdentInformasjon(oldFnr, true, IdentGruppe.FOLKEREGISTERIDENT),
-                                            ),
-                                    ),
-                                ),
-                        ),
-                    ),
-                ),
-            )
-            val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
-
-            result[oldFnr] shouldNotBe null
-
-            DbListener.dataSource.transaction { tx ->
-                AuditRepository.getAuditByPersonId(tx, result[oldFnr]!!) shouldNotBeNull {
-                    size shouldBe 2
-                    this.any { it.tag == AuditTag.OPPRETTET_PERSON } shouldBe true
-                    this.any { it.tag == AuditTag.OPPDATERT_PERSONIDENTIFIKATOR } shouldBe true
+        Given("en tom liste med fødselsnumre") {
+            When("personId-er hentes og fødselsnumre sjekkes") {
+                Then("skal det returneres et tomt resultat uten exception") {
+                    val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(emptyList(), AUDIT_SYSTEM)
+                    result.size shouldBe 0
                 }
             }
         }
 
-        test("getPersonIdAndCheckFoedselsnumreIsUpdated skal håndtere mix av eksisterende og nye personer") {
-            val existingFnr = "10101000010"
-            val newFnr = "15467834260"
-            val fnrList = listOf(existingFnr, newFnr)
-            DbListener.loadDataSet("database/person/persondata.sql")
+        Given("persondata er lastet i databasen for oppslag av person") {
+            When("personId hentes eller opprettes for en allerede registrert person") {
+                Then("skal eksisterende person returneres uten ny opprettelse") {
+                    val fnr = "10101000010"
+                    DbListener.loadDataSet("database/person/persondata.sql")
+                    DbListener.dataSource.transaction { tx ->
+                        val (personId, opprettet) =
+                            personService
+                                .findPersonIdOrCreatePersonByFnr(
+                                    fnr = Personidentifikator(fnr),
+                                    informasjon = "TEST",
+                                    brukerId = AUDIT_SYSTEM,
+                                    tx = tx,
+                                )
+                        personId shouldNotBe null
+                        opprettet shouldBe false
 
-            WiremockListener.wiremockPDLStub(generateHentIdenterBolk(newFnr))
-            val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
+                        val auditList = AuditRepository.getAuditByPersonId(tx, personId)
+                        auditList.size shouldBe 1
+                        auditList.first().tag shouldBe AuditTag.OPPRETTET_PERSON
+                        auditList.first().informasjon shouldBe "Person 10 opprettet"
+                    }
+                }
+            }
 
-            result.size shouldBe 2
-            result[existingFnr] shouldNotBe null
-            result[newFnr] shouldNotBe null
+            When("personId hentes eller opprettes for en ny person") {
+                Then("skal ny person opprettes og returneres") {
+                    val fnr = "15467834260"
+                    DbListener.loadDataSet("database/person/persondata.sql")
+                    DbListener.dataSource.transaction { tx ->
+                        val (personId, opprettet) =
+                            personService
+                                .findPersonIdOrCreatePersonByFnr(
+                                    fnr = Personidentifikator(fnr),
+                                    informasjon = "TEST",
+                                    brukerId = AUDIT_SYSTEM,
+                                    tx = tx,
+                                )
+                        personId shouldNotBe null
+                        opprettet shouldBe true
+
+                        val auditList = AuditRepository.getAuditByPersonId(tx, personId)
+                        auditList.size shouldBe 1
+                        auditList.first().tag shouldBe AuditTag.OPPRETTET_PERSON
+                        auditList.first().informasjon shouldBe "TEST"
+                    }
+                }
+            }
         }
 
-        test("getPersonIdAndCheckFoedselsnumreIsUpdated skal returnere null for fnr som ikke fins i PDL") {
-            val invalidFnr = "00000000000"
-            val fnrList = listOf(invalidFnr)
-            DbListener.loadDataSet("database/person/persondata.sql")
+        Given("persondata er lastet i databasen for kontroll av fødselsnumre") {
+            When("alle oppgitte fødselsnumre allerede finnes som personer") {
+                Then("skal det returneres map med personId for alle eksisterende personer") {
+                    val fnrList = listOf("10101000010", "10101000011", "10101000012")
+                    DbListener.loadDataSet("database/person/persondata.sql")
 
-            WiremockListener.wiremockPDLStub(
-                Json.encodeToString(
-                    GraphQLResponse(
-                        HentIdenterBolk.Result(
-                            hentIdenterBolk =
-                                listOf(),
-                        ),
-                    ),
-                ),
-            )
-            val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
-            result[invalidFnr] shouldBe null
-        }
+                    WiremockListener.wiremockPDLStub(generateHentIdenterBolk(*fnrList.toTypedArray()))
+                    val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
 
-        test("getPersonIdAndCheckFoedselsnumreIsUpdated skal håndtere store mengder fnr med chunking") {
-            val fnrList = (1..100).map { "1010100%04d".format(it) }
+                    result.size shouldBe 3
+                    result.values.forEach { personId ->
+                        personId shouldNotBe null
+                    }
+                }
+            }
 
-            WiremockListener.wiremockPDLStub(generateHentIdenterBolk(*fnrList.toTypedArray()))
-            DbListener.loadDataSet("database/person/persondata.sql")
+            When("ukjent person finnes i PDL") {
+                Then("skal ny person opprettes fra PDL-data") {
+                    val fnrList = listOf("15467834260")
+                    DbListener.loadDataSet("database/person/persondata.sql")
 
-            val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM, 30)
+                    WiremockListener.wiremockPDLStub(generateHentIdenterBolk(*fnrList.toTypedArray()))
+                    val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
 
-            WiremockListener.wiremock.verify(4, postRequestedFor(urlEqualTo("/graphql")))
-            result.size shouldBe fnrList.size
-            result.values.shouldNotContainNull()
-        }
+                    result.size shouldBe 1
+                    result[fnrList[0]] shouldNotBe null
+                }
+            }
 
-        test("getPersonIdAndCheckFoedselsnumreIsUpdated skal registrere gammelt fnr på eksisterende person id når ny ident allerede er registrert") {
-            val oldFnr = "10100000098" // Ikke i DB, vil slå opp i PDL
-            val existingActiveIdent = "10101000010" // Ligger allerede i DB via persondata.sql
-            val fnrList = listOf(oldFnr)
+            When("PDL returnerer en ny ident for et eksisterende fødselsnummer") {
+                Then("skal fødselsnummeret oppdateres og audit logges") {
+                    val oldFnr = "10101000098"
+                    val newFnr = "10101000099"
+                    val fnrList = listOf(oldFnr)
+                    DbListener.loadDataSet("database/person/persondata.sql")
 
-            DbListener.loadDataSet("database/person/persondata.sql")
-
-            // Mock PDL-responsen til å si at oldFnr i dag peker til existingActiveIdent som ikke er historisk
-            WiremockListener.wiremockPDLStub(
-                Json.encodeToString(
-                    GraphQLResponse(
-                        HentIdenterBolk.Result(
-                            hentIdenterBolk =
-                                listOf(
-                                    HentIdenterBolkResult(
-                                        ident = oldFnr,
-                                        identer =
-                                            listOf(
-                                                IdentInformasjon(existingActiveIdent, false, IdentGruppe.FOLKEREGISTERIDENT),
-                                                IdentInformasjon(oldFnr, true, IdentGruppe.FOLKEREGISTERIDENT),
+                    WiremockListener.wiremockPDLStub(
+                        Json.encodeToString(
+                            GraphQLResponse(
+                                HentIdenterBolk.Result(
+                                    hentIdenterBolk =
+                                        listOf(
+                                            HentIdenterBolkResult(
+                                                ident = oldFnr,
+                                                identer =
+                                                    listOf(
+                                                        IdentInformasjon(newFnr, false, IdentGruppe.FOLKEREGISTERIDENT),
+                                                        IdentInformasjon(oldFnr, true, IdentGruppe.FOLKEREGISTERIDENT),
+                                                    ),
                                             ),
-                                    ),
+                                        ),
                                 ),
+                            ),
                         ),
-                    ),
-                ),
-            )
+                    )
+                    val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
 
-            val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
+                    result[oldFnr] shouldNotBe null
 
-            result[oldFnr] shouldNotBe null
+                    DbListener.dataSource.transaction { tx ->
+                        AuditRepository.getAuditByPersonId(tx, result[oldFnr]!!) shouldNotBeNull {
+                            size shouldBe 2
+                            this.any { it.tag == AuditTag.OPPRETTET_PERSON } shouldBe true
+                            this.any { it.tag == AuditTag.OPPDATERT_PERSONIDENTIFIKATOR } shouldBe true
+                        }
+                    }
+                }
+            }
 
-            // Hent audits for å sjekke at logikken for "allerede registrert" ble kjørt
-            DbListener.dataSource.transaction { tx ->
-                val auditLogs = AuditRepository.getAuditByPersonId(tx, result[oldFnr]!!)
+            When("listen inneholder både eksisterende og nye personer") {
+                Then("skal både eksisterende og nye personId-er returneres") {
+                    val existingFnr = "10101000010"
+                    val newFnr = "15467834260"
+                    val fnrList = listOf(existingFnr, newFnr)
+                    DbListener.loadDataSet("database/person/persondata.sql")
 
-                auditLogs.shouldNotBeNull {
-                    // Sjekker at den nye grenen opprettet riktig OPPDATERT_PERSONIDENTIFIKATOR-audit
-                    this.any {
-                        it.tag == AuditTag.OPPDATERT_PERSONIDENTIFIKATOR &&
-                            it.informasjon == "Oppdatert gamle foedselsnummer: $oldFnr"
-                    } shouldBe true
+                    WiremockListener.wiremockPDLStub(generateHentIdenterBolk(newFnr))
+                    val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
+
+                    result.size shouldBe 2
+                    result[existingFnr] shouldNotBe null
+                    result[newFnr] shouldNotBe null
+                }
+            }
+
+            When("fødselsnummeret ikke finnes i PDL") {
+                Then("skal resultatet inneholde null for det fødselsnummeret") {
+                    val invalidFnr = "00000000000"
+                    val fnrList = listOf(invalidFnr)
+                    DbListener.loadDataSet("database/person/persondata.sql")
+
+                    WiremockListener.wiremockPDLStub(
+                        Json.encodeToString(
+                            GraphQLResponse(
+                                HentIdenterBolk.Result(
+                                    hentIdenterBolk =
+                                        listOf(),
+                                ),
+                            ),
+                        ),
+                    )
+                    val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
+                    result[invalidFnr] shouldBe null
+                }
+            }
+
+            When("mange fødselsnumre behandles med chunking") {
+                Then("skal alle personId-er returneres og PDL kalles i flere chunker") {
+                    val fnrList = (1..100).map { "1010100%04d".format(it) }
+
+                    WiremockListener.wiremockPDLStub(generateHentIdenterBolk(*fnrList.toTypedArray()))
+                    DbListener.loadDataSet("database/person/persondata.sql")
+
+                    val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM, 30)
+
+                    WiremockListener.wiremock.verify(4, postRequestedFor(urlEqualTo("/graphql")))
+                    result.size shouldBe fnrList.size
+                    result.values.shouldNotContainNull()
+                }
+            }
+
+            When("gammelt fødselsnummer peker til en ident som allerede er registrert") {
+                Then("skal gammelt fødselsnummer registreres på eksisterende personId") {
+                    val oldFnr = "10100000098" // Ikke i DB, vil slå opp i PDL
+                    val existingActiveIdent = "10101000010" // Ligger allerede i DB via persondata.sql
+                    val fnrList = listOf(oldFnr)
+
+                    DbListener.loadDataSet("database/person/persondata.sql")
+
+                    // Mock PDL-responsen til å si at oldFnr i dag peker til existingActiveIdent som ikke er historisk
+                    WiremockListener.wiremockPDLStub(
+                        Json.encodeToString(
+                            GraphQLResponse(
+                                HentIdenterBolk.Result(
+                                    hentIdenterBolk =
+                                        listOf(
+                                            HentIdenterBolkResult(
+                                                ident = oldFnr,
+                                                identer =
+                                                    listOf(
+                                                        IdentInformasjon(existingActiveIdent, false, IdentGruppe.FOLKEREGISTERIDENT),
+                                                        IdentInformasjon(oldFnr, true, IdentGruppe.FOLKEREGISTERIDENT),
+                                                    ),
+                                            ),
+                                        ),
+                                ),
+                            ),
+                        ),
+                    )
+
+                    val result = personService.getPersonIdAndCheckFoedselsnumreIsUpdated(fnrList, AUDIT_SYSTEM)
+
+                    result[oldFnr] shouldNotBe null
+
+                    // Hent audits for å sjekke at logikken for "allerede registrert" ble kjørt
+                    DbListener.dataSource.transaction { tx ->
+                        val auditLogs = AuditRepository.getAuditByPersonId(tx, result[oldFnr]!!)
+
+                        auditLogs.shouldNotBeNull {
+                            // Sjekker at den nye grenen opprettet riktig OPPDATERT_PERSONIDENTIFIKATOR-audit
+                            this.any {
+                                it.tag == AuditTag.OPPDATERT_PERSONIDENTIFIKATOR &&
+                                    it.informasjon == "Oppdatert gamle foedselsnummer: $oldFnr"
+                            } shouldBe true
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/no/nav/sokos/skattekort/person/kafka/IdentifikatorEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/person/kafka/IdentifikatorEndringServiceTest.kt
@@ -1,7 +1,7 @@
 package no.nav.sokos.skattekort.person.kafka
 
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 
 import no.nav.sokos.skattekort.infrastructure.pdl.PdlClientService
@@ -21,7 +21,7 @@ import no.nav.sokos.skattekort.utils.TestUtils.readFile
 import no.nav.sokos.skattekort.utils.createTestHttpClient
 
 class IdentifikatorEndringServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(DbListener, WiremockListener)
 
         val pdlClientService: PdlClientService by lazy {
@@ -40,97 +40,111 @@ class IdentifikatorEndringServiceTest :
             )
         }
 
-        test("processIdentifikatorEndring oppdater person med ny folkeregisteridentifikator") {
-            DbListener.loadDataSet("database/person/persondata.sql")
+        Given("persondata er lastet og en gyldig identifikatorendring mottas") {
+            When("en opprettet folkeregisteridentifikator behandles") {
+                Then("skal personen oppdateres med ny folkeregisteridentifikator") {
+                    DbListener.loadDataSet("database/person/persondata.sql")
 
-            val pdlResponse = readFile("/pdl/hentIdenterBolkOkResponse.json")
-            wiremockPDLStub(pdlResponse)
+                    val pdlResponse = readFile("/pdl/hentIdenterBolkOkResponse.json")
+                    wiremockPDLStub(pdlResponse)
 
-            val hendelse = getPersonHendelseMockData()
-            val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
+                    val hendelse = getPersonHendelseMockData()
+                    val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
 
-            identifikatorEndringService.processIdentifikatorEndring(hendelse)
-            DbListener.dataSource.transaction { tx ->
-                val person = PersonRepository.findPersonByFnr(tx, personidentifikator)!!
-                person.foedselsnummer.fnr shouldBe personidentifikator
+                    identifikatorEndringService.processIdentifikatorEndring(hendelse)
+                    DbListener.dataSource.transaction { tx ->
+                        val person = PersonRepository.findPersonByFnr(tx, personidentifikator)!!
+                        person.foedselsnummer.fnr shouldBe personidentifikator
 
-                val auditList = AuditRepository.getAuditByPersonId(tx, person.id!!)
-                withClue("Skal ha 3 audit meldinger") { auditList.size shouldBe 3 }
-                auditMatcher(auditList[1], person)
+                        val auditList = AuditRepository.getAuditByPersonId(tx, person.id!!)
+                        withClue("Skal ha 3 audit meldinger") { auditList.size shouldBe 3 }
+                        auditMatcher(auditList[1], person)
 
-                val bestillingList = DBTestUtils.getAllBestilling(tx)
-                withClue("Skal opprette 1 ny bestilling") { bestillingList.size shouldBe 1 }
+                        val bestillingList = DBTestUtils.getAllBestilling(tx)
+                        withClue("Skal opprette 1 ny bestilling") { bestillingList.size shouldBe 1 }
+                    }
+                }
+            }
+
+            When("en korrigert folkeregisteridentifikator behandles") {
+                Then("skal personen oppdateres med ny folkeregisteridentifikator") {
+                    DbListener.loadDataSet("database/person/persondata.sql")
+
+                    val pdlResponse = readFile("/pdl/hentIdenterBolkOkResponse.json")
+                    wiremockPDLStub(pdlResponse)
+
+                    val hendelse =
+                        getPersonHendelseMockData().copy(
+                            endringstype = EndringstypeDTO.KORRIGERT,
+                        )
+                    val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
+
+                    identifikatorEndringService.processIdentifikatorEndring(hendelse)
+                    DbListener.dataSource.transaction { tx ->
+                        val person = PersonRepository.findPersonByFnr(tx, personidentifikator)!!
+                        person.foedselsnummer.fnr shouldBe personidentifikator
+
+                        val auditList = AuditRepository.getAuditByPersonId(tx, person.id!!)
+                        withClue("Skal ha 3 audit meldinger") { auditList.size shouldBe 3 }
+                        auditMatcher(auditList[1], person)
+
+                        val bestillingList = DBTestUtils.getAllBestilling(tx)
+                        withClue("Skal opprette 1 ny bestilling") { bestillingList.size shouldBe 1 }
+                    }
+                }
             }
         }
 
-        test("processIdentifikatorEndring oppdater person med ny folkeregisteridentifikator (KORRIGERT)") {
-            DbListener.loadDataSet("database/person/persondata.sql")
+        Given("persondata er lastet og hendelsen ikke skal behandles videre") {
+            When("endringstypen er opphørt") {
+                Then("skal hendelsen ignoreres") {
+                    DbListener.loadDataSet("database/person/persondata.sql")
 
-            val pdlResponse = readFile("/pdl/hentIdenterBolkOkResponse.json")
-            wiremockPDLStub(pdlResponse)
+                    val hendelse =
+                        getPersonHendelseMockData().copy(
+                            endringstype = EndringstypeDTO.OPPHOERT,
+                        )
+                    val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
 
-            val hendelse =
-                getPersonHendelseMockData().copy(
-                    endringstype = EndringstypeDTO.KORRIGERT,
-                )
-            val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
-
-            identifikatorEndringService.processIdentifikatorEndring(hendelse)
-            DbListener.dataSource.transaction { tx ->
-                val person = PersonRepository.findPersonByFnr(tx, personidentifikator)!!
-                person.foedselsnummer.fnr shouldBe personidentifikator
-
-                val auditList = AuditRepository.getAuditByPersonId(tx, person.id!!)
-                withClue("Skal ha 3 audit meldinger") { auditList.size shouldBe 3 }
-                auditMatcher(auditList[1], person)
-
-                val bestillingList = DBTestUtils.getAllBestilling(tx)
-                withClue("Skal opprette 1 ny bestilling") { bestillingList.size shouldBe 1 }
+                    identifikatorEndringService.processIdentifikatorEndring(hendelse)
+                    DbListener.dataSource.transaction { tx ->
+                        PersonRepository.findPersonByFnr(tx, personidentifikator) shouldBe null
+                    }
+                }
             }
-        }
 
-        test("processIdentifikatorEndring ignorer med andre opplysningstype") {
-            DbListener.loadDataSet("database/person/persondata.sql")
+            When("PDL ikke finner historiske identer") {
+                Then("skal hendelsen ignoreres") {
+                    DbListener.loadDataSet("database/person/persondata.sql")
 
-            val hendelse =
-                getPersonHendelseMockData().copy(
-                    endringstype = EndringstypeDTO.OPPHOERT,
-                )
-            val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
+                    val pdlResponse = readFile("/pdl/hentIdenterBolkOkUtenHistoriskResponse.json")
+                    wiremockPDLStub(pdlResponse)
 
-            identifikatorEndringService.processIdentifikatorEndring(hendelse)
-            DbListener.dataSource.transaction { tx ->
-                PersonRepository.findPersonByFnr(tx, personidentifikator) shouldBe null
+                    val hendelse = getPersonHendelseMockData()
+                    val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
+
+                    identifikatorEndringService.processIdentifikatorEndring(hendelse)
+                    DbListener.dataSource.transaction { tx ->
+                        PersonRepository.findPersonByFnr(tx, personidentifikator) shouldBe null
+                    }
+                }
             }
-        }
 
-        test("processIdentifikatorEndring ignorer med ingen historiske identer funnet fra PDL") {
-            DbListener.loadDataSet("database/person/persondata.sql")
+            When("opplysningstypen ikke er FOLKEREGISTERIDENTIFIKATOR_V1") {
+                Then("skal hendelsen ignoreres") {
+                    DbListener.loadDataSet("database/person/persondata.sql")
 
-            val pdlResponse = readFile("/pdl/hentIdenterBolkOkUtenHistoriskResponse.json")
-            wiremockPDLStub(pdlResponse)
+                    val hendelse =
+                        getPersonHendelseMockData().copy(
+                            opplysningstype = "ANNEN_IDENTIFIKATOR",
+                        )
+                    val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
 
-            val hendelse = getPersonHendelseMockData()
-            val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
-
-            identifikatorEndringService.processIdentifikatorEndring(hendelse)
-            DbListener.dataSource.transaction { tx ->
-                PersonRepository.findPersonByFnr(tx, personidentifikator) shouldBe null
-            }
-        }
-
-        test("processIdentifikatorEndring ignorer med folkeregisteridentifikator ikke er FOLKEREGISTERIDENTIFIKATOR_V1") {
-            DbListener.loadDataSet("database/person/persondata.sql")
-
-            val hendelse =
-                getPersonHendelseMockData().copy(
-                    opplysningstype = "ANNEN_IDENTIFIKATOR",
-                )
-            val personidentifikator = Personidentifikator(hendelse.folkeregisteridentifikator!!.identifikasjonsnummer)
-
-            identifikatorEndringService.processIdentifikatorEndring(hendelse)
-            DbListener.dataSource.transaction { tx ->
-                PersonRepository.findPersonByFnr(tx, personidentifikator) shouldBe null
+                    identifikatorEndringService.processIdentifikatorEndring(hendelse)
+                    DbListener.dataSource.transaction { tx ->
+                        PersonRepository.findPersonByFnr(tx, personidentifikator) shouldBe null
+                    }
+                }
             }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/security/AccessPolicyTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/security/AccessPolicyTest.kt
@@ -1,78 +1,102 @@
 package no.nav.sokos.skattekort.security
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
 class AccessPolicyTest :
-    FunSpec({
-        test("ALLOWED_SCOPES should match Scope enum values") {
-            AccessPolicy.ALLOWED_SCOPES.toList().sorted() shouldContainExactly
-                Scope.entries.map { it.value }.sorted()
-        }
-
-        test("ALLOWED_ROLES should match Role enum values") {
-            AccessPolicy.ALLOWED_ROLES.toList().sorted() shouldContainExactly
-                Role.entries.map { it.value }.sorted()
-        }
-
-        context("hasRequiredScope") {
-            test("returns true when required scope is present and allowed") {
-                AccessPolicy.hasRequiredScope(
-                    scopes = listOf("other.scope", Scope.HENT_SKATTEKORT_SCOPE.value),
-                    requiredScope = Scope.HENT_SKATTEKORT_SCOPE.value,
-                ) shouldBe true
-            }
-
-            test("returns false when required scope is missing") {
-                AccessPolicy.hasRequiredScope(
-                    scopes = listOf("other.scope"),
-                    requiredScope = Scope.HENT_SKATTEKORT_SCOPE.value,
-                ) shouldBe false
-            }
-
-            test("returns false when required scope is not allowed even if present") {
-                AccessPolicy.hasRequiredScope(
-                    scopes = listOf("custom.read"),
-                    requiredScope = "custom.read",
-                ) shouldBe false
-            }
-
-            test("returns false when scopes list is empty") {
-                AccessPolicy.hasRequiredScope(
-                    scopes = emptyList(),
-                    requiredScope = Scope.HENT_SKATTEKORT_SCOPE.value,
-                ) shouldBe false
+    BehaviorSpec({
+        Given("tilgangspolicyens konfigurerte scopes") {
+            When("tillatte scopes sammenlignes med Scope-enum") {
+                Then("skal ALLOWED_SCOPES matche verdiene i Scope-enum") {
+                    AccessPolicy.ALLOWED_SCOPES.toList().sorted() shouldContainExactly
+                        Scope.entries.map { it.value }.sorted()
+                }
             }
         }
 
-        context("hasRequiredRole") {
-            test("returns true when required role is present and allowed") {
-                AccessPolicy.hasRequiredRole(
-                    roles = listOf("other.role", Role.HENT_SKATTEKORT_ROLE.value),
-                    requiredRole = Role.HENT_SKATTEKORT_ROLE.value,
-                ) shouldBe true
+        Given("tilgangspolicyens konfigurerte roller") {
+            When("tillatte roller sammenlignes med Role-enum") {
+                Then("skal ALLOWED_ROLES matche verdiene i Role-enum") {
+                    AccessPolicy.ALLOWED_ROLES.toList().sorted() shouldContainExactly
+                        Role.entries.map { it.value }.sorted()
+                }
+            }
+        }
+
+        Given("hasRequiredScope") {
+            When("påkrevd scope finnes og er tillatt") {
+                Then("skal true returneres") {
+                    AccessPolicy.hasRequiredScope(
+                        scopes = listOf("other.scope", Scope.HENT_SKATTEKORT_SCOPE.value),
+                        requiredScope = Scope.HENT_SKATTEKORT_SCOPE.value,
+                    ) shouldBe true
+                }
             }
 
-            test("returns false when required role is missing") {
-                AccessPolicy.hasRequiredRole(
-                    roles = listOf("other.role"),
-                    requiredRole = Role.HENT_SKATTEKORT_ROLE.value,
-                ) shouldBe false
+            When("påkrevd scope mangler") {
+                Then("skal false returneres") {
+                    AccessPolicy.hasRequiredScope(
+                        scopes = listOf("other.scope"),
+                        requiredScope = Scope.HENT_SKATTEKORT_SCOPE.value,
+                    ) shouldBe false
+                }
             }
 
-            test("returns false when required role is not allowed even if present") {
-                AccessPolicy.hasRequiredRole(
-                    roles = listOf("custom.role"),
-                    requiredRole = "custom.role",
-                ) shouldBe false
+            When("påkrevd scope finnes men ikke er tillatt") {
+                Then("skal false returneres") {
+                    AccessPolicy.hasRequiredScope(
+                        scopes = listOf("custom.read"),
+                        requiredScope = "custom.read",
+                    ) shouldBe false
+                }
             }
 
-            test("returns false when roles list is empty") {
-                AccessPolicy.hasRequiredRole(
-                    roles = emptyList(),
-                    requiredRole = Role.HENT_SKATTEKORT_ROLE.value,
-                ) shouldBe false
+            When("scope-listen er tom") {
+                Then("skal false returneres") {
+                    AccessPolicy.hasRequiredScope(
+                        scopes = emptyList(),
+                        requiredScope = Scope.HENT_SKATTEKORT_SCOPE.value,
+                    ) shouldBe false
+                }
+            }
+        }
+
+        Given("hasRequiredRole") {
+            When("påkrevd rolle finnes og er tillatt") {
+                Then("skal true returneres") {
+                    AccessPolicy.hasRequiredRole(
+                        roles = listOf("other.role", Role.HENT_SKATTEKORT_ROLE.value),
+                        requiredRole = Role.HENT_SKATTEKORT_ROLE.value,
+                    ) shouldBe true
+                }
+            }
+
+            When("påkrevd rolle mangler") {
+                Then("skal false returneres") {
+                    AccessPolicy.hasRequiredRole(
+                        roles = listOf("other.role"),
+                        requiredRole = Role.HENT_SKATTEKORT_ROLE.value,
+                    ) shouldBe false
+                }
+            }
+
+            When("påkrevd rolle finnes men ikke er tillatt") {
+                Then("skal false returneres") {
+                    AccessPolicy.hasRequiredRole(
+                        roles = listOf("custom.role"),
+                        requiredRole = "custom.role",
+                    ) shouldBe false
+                }
+            }
+
+            When("rolle-listen er tom") {
+                Then("skal false returneres") {
+                    AccessPolicy.hasRequiredRole(
+                        roles = emptyList(),
+                        requiredRole = Role.HENT_SKATTEKORT_ROLE.value,
+                    ) shouldBe false
+                }
             }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/security/AuthorizationGuardTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/security/AuthorizationGuardTest.kt
@@ -3,7 +3,7 @@ package no.nav.sokos.skattekort.security
 import com.auth0.jwt.interfaces.Payload
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -20,130 +20,164 @@ import no.nav.sokos.skattekort.security.TokenTestUtils.generateToken
 import no.nav.sokos.skattekort.security.TokenTestUtils.getPrincipal
 
 class AuthorizationGuardTest :
-    FunSpec({
-        test("getNavIdentOrNull returns NAVident when present") {
-            val payload = mockk<Payload>()
-            every { payload.getClaim(JWT_CLAIM_NAVIDENT).asString() } returns "aUser"
+    BehaviorSpec({
+        Given("et kall med principal som inneholder NAV-ident") {
+            When("NAV-ident hentes fra principal") {
+                Then("skal NAV-ident returneres") {
+                    val payload = mockk<Payload>()
+                    every { payload.getClaim(JWT_CLAIM_NAVIDENT).asString() } returns "aUser"
 
-            val principal = mockk<JWTPrincipal>()
-            every { principal.payload } returns payload
+                    val principal = mockk<JWTPrincipal>()
+                    every { principal.payload } returns payload
 
-            val call = mockk<ApplicationCall>(relaxed = true)
-            every { call.principal<JWTPrincipal>() } returns principal
-            call.getNavIdentOrNull() shouldBe "aUser"
-        }
-
-        test("getNavIdentOrNull returns null when principal is missing") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            every { call.principal<JWTPrincipal>() } returns null
-
-            call.getNavIdentOrNull() shouldBe null
-        }
-
-        test("getCallingSystem returns Unknown when principal is missing") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            every { call.principal<JWTPrincipal>() } returns null
-
-            call.getCallingSystem() shouldBe "Unknown"
-        }
-
-        test("requirePermission with scope or role should not throw any exception") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-
-            val token = generateToken(scopes = Scope.entries.map { it.value }, roles = Role.entries.map { it.value })
-            every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
-
-            shouldNotThrowAny { call.requirePermission(requiredScope = Scope.HENT_SKATTEKORT_SCOPE, requiredRole = Role.HENT_SKATTEKORT_ROLE) }
-        }
-
-        test("requirePermission throws AuthenticationException when principal is missing") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            every { call.principal<JWTPrincipal>() } returns null
-
-            val response =
-                shouldThrow<AuthenticationException> {
-                    call.requirePermission(Scope.HENT_SKATTEKORT_SCOPE, Role.HENT_SKATTEKORT_ROLE)
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    every { call.principal<JWTPrincipal>() } returns principal
+                    call.getNavIdentOrNull() shouldBe "aUser"
                 }
-
-            response.message shouldBe "No principal found - authentication not configured"
+            }
         }
 
-        test("requirePermission throws AuthorizationException with unknown scope or role") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            val mockScope = mockk<Scope>(relaxed = true)
-            val mockRole = mockk<Role>(relaxed = true)
+        Given("et kall uten principal") {
+            When("NAV-ident hentes") {
+                Then("skal null returneres") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    every { call.principal<JWTPrincipal>() } returns null
 
-            val token = generateToken(scopes = Scope.entries.map { it.value }, roles = Role.entries.map { it.value })
-            every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
-
-            shouldThrow<AuthorizationException> {
-                call.requirePermission(mockScope, mockRole)
-            }.message shouldBe "Missing required scope or role"
-        }
-
-        test("requireScope should not throw any exception") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            val token = generateToken(scopes = Scope.entries.map { it.value })
-            every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
-
-            shouldNotThrowAny { call.requireScope(Scope.HENT_SKATTEKORT_SCOPE) }
-        }
-
-        test("requireScope throws AuthenticationException when principal is missing") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            every { call.principal<JWTPrincipal>() } returns null
-
-            val response =
-                shouldThrow<AuthenticationException> {
-                    call.requireScope(Scope.HENT_SKATTEKORT_SCOPE)
+                    call.getNavIdentOrNull() shouldBe null
                 }
-            response.message shouldBe "No principal found - authentication not configured"
-        }
+            }
 
-        test("requireScope throws AuthorizationException with unknown scope") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            val mockScope = mockk<Scope>(relaxed = true)
+            When("kallende system hentes") {
+                Then("skal Unknown returneres") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    every { call.principal<JWTPrincipal>() } returns null
 
-            val token = generateToken(scopes = Scope.entries.map { it.value })
-            every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
-
-            val response =
-                shouldThrow<AuthorizationException> {
-                    call.requireScope(mockScope)
+                    call.getCallingSystem() shouldBe "Unknown"
                 }
-            response.message shouldBe "Missing required scope"
-        }
+            }
 
-        test("requireRole should not throw any exception") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            val token = generateToken(roles = Role.entries.map { it.value })
-            every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
+            When("requirePermission kalles") {
+                Then("skal AuthenticationException kastes") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    every { call.principal<JWTPrincipal>() } returns null
 
-            shouldNotThrowAny { call.requireRole(Role.HENT_SKATTEKORT_ROLE) }
-        }
+                    val response =
+                        shouldThrow<AuthenticationException> {
+                            call.requirePermission(Scope.HENT_SKATTEKORT_SCOPE, Role.HENT_SKATTEKORT_ROLE)
+                        }
 
-        test("requireRole throws AuthenticationException when principal is missing") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            every { call.principal<JWTPrincipal>() } returns null
-
-            val response =
-                shouldThrow<AuthenticationException> {
-                    call.requireRole(Role.HENT_SKATTEKORT_ROLE)
+                    response.message shouldBe "No principal found - authentication not configured"
                 }
+            }
 
-            response.message shouldBe "No principal found - authentication not configured"
+            When("requireScope kalles") {
+                Then("skal AuthenticationException kastes") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    every { call.principal<JWTPrincipal>() } returns null
+
+                    val response =
+                        shouldThrow<AuthenticationException> {
+                            call.requireScope(Scope.HENT_SKATTEKORT_SCOPE)
+                        }
+                    response.message shouldBe "No principal found - authentication not configured"
+                }
+            }
+
+            When("requireRole kalles") {
+                Then("skal AuthenticationException kastes") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    every { call.principal<JWTPrincipal>() } returns null
+
+                    val response =
+                        shouldThrow<AuthenticationException> {
+                            call.requireRole(Role.HENT_SKATTEKORT_ROLE)
+                        }
+
+                    response.message shouldBe "No principal found - authentication not configured"
+                }
+            }
         }
 
-        test("requireRole throws AuthorizationException with unknown role") {
-            val call = mockk<ApplicationCall>(relaxed = true)
-            val mockRole = mockk<Role>(relaxed = true)
-            val token = generateToken(scopes = Scope.entries.map { it.value })
-            every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
+        Given("et kall med gyldig principal og nødvendige tilganger") {
+            When("requirePermission kalles med gyldig scope eller rolle") {
+                Then("skal det ikke kastes exception") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
 
-            val response =
-                shouldThrow<AuthorizationException> {
-                    call.requireRole(mockRole)
+                    val token = generateToken(scopes = Scope.entries.map { it.value }, roles = Role.entries.map { it.value })
+                    every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
+
+                    shouldNotThrowAny {
+                        call.requirePermission(requiredScope = Scope.HENT_SKATTEKORT_SCOPE, requiredRole = Role.HENT_SKATTEKORT_ROLE)
+                    }
                 }
-            response.message shouldBe "Missing required role"
+            }
+
+            When("requireScope kalles med gyldig scope") {
+                Then("skal det ikke kastes exception") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    val token = generateToken(scopes = Scope.entries.map { it.value })
+                    every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
+
+                    shouldNotThrowAny { call.requireScope(Scope.HENT_SKATTEKORT_SCOPE) }
+                }
+            }
+
+            When("requireRole kalles med gyldig rolle") {
+                Then("skal det ikke kastes exception") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    val token = generateToken(roles = Role.entries.map { it.value })
+                    every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
+
+                    shouldNotThrowAny { call.requireRole(Role.HENT_SKATTEKORT_ROLE) }
+                }
+            }
+        }
+
+        Given("et kall med principal men uten etterspurt tilgang") {
+            When("requirePermission kalles med ukjent scope eller rolle") {
+                Then("skal AuthorizationException kastes") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    val mockScope = mockk<Scope>(relaxed = true)
+                    val mockRole = mockk<Role>(relaxed = true)
+
+                    val token = generateToken(scopes = Scope.entries.map { it.value }, roles = Role.entries.map { it.value })
+                    every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
+
+                    shouldThrow<AuthorizationException> {
+                        call.requirePermission(mockScope, mockRole)
+                    }.message shouldBe "Missing required scope or role"
+                }
+            }
+
+            When("requireScope kalles med ukjent scope") {
+                Then("skal AuthorizationException kastes") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    val mockScope = mockk<Scope>(relaxed = true)
+
+                    val token = generateToken(scopes = Scope.entries.map { it.value })
+                    every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
+
+                    val response =
+                        shouldThrow<AuthorizationException> {
+                            call.requireScope(mockScope)
+                        }
+                    response.message shouldBe "Missing required scope"
+                }
+            }
+
+            When("requireRole kalles med ukjent rolle") {
+                Then("skal AuthorizationException kastes") {
+                    val call = mockk<ApplicationCall>(relaxed = true)
+                    val mockRole = mockk<Role>(relaxed = true)
+                    val token = generateToken(scopes = Scope.entries.map { it.value })
+                    every { call.principal<JWTPrincipal>() } returns token.getPrincipal()
+
+                    val response =
+                        shouldThrow<AuthorizationException> {
+                            call.requireRole(mockRole)
+                        }
+                    response.message shouldBe "Missing required role"
+                }
+            }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortRepositoryTest.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import kotliquery.TransactionalSession
 
@@ -13,97 +13,116 @@ import no.nav.sokos.skattekort.person.PersonId
 import no.nav.sokos.skattekort.util.SQLUtils.transaction
 
 class SkattekortRepositoryTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(DbListener)
 
         fun <T> tx(block: (TransactionalSession) -> T): T = DbListener.dataSource.transaction { tx -> block(tx) }
 
-        test("Hent riktig skattekort når det finnes mange") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, "01010112345"),
-                aSkattekort(
-                    id = 6986540,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "1058529683",
-                    inntektsaar = 2025,
-                    opprettet = LocalDateTime.parse("2025-12-14T17:16:10.276264"),
-                ),
-                aSkattekort(
-                    id = 8732414,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "567677175",
-                    inntektsaar = 2026,
-                    opprettet = LocalDateTime.parse("2025-12-16T19:25:47.520911"),
-                ),
-                aSkattekort(
-                    id = 10013248,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "1085419887",
-                    inntektsaar = 2025,
-                    opprettet = LocalDateTime.parse("2025-12-19T15:43:47.381757"),
-                ),
-                aSkattekort(
-                    id = 10014205,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "1085419887",
-                    inntektsaar = 2025,
-                    opprettet = LocalDateTime.parse("2025-12-19T15:46:47.541476"),
-                ),
-                aSkattekort(
-                    id = 10014992,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "1085419887",
-                    inntektsaar = 2025,
-                    opprettet = LocalDateTime.parse("2025-12-19T15:49:47.685548"),
-                ),
-                aSkattekort(
-                    id = 10015752,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "1085419887",
-                    inntektsaar = 2025,
-                    opprettet = LocalDateTime.parse("2025-12-19T15:52:47.833756"),
-                ),
-                aSkattekort(
-                    id = 10016224,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "1088125212",
-                    inntektsaar = 2025,
-                    opprettet = LocalDateTime.parse("2025-12-19T16:37:45.751951"),
-                ),
-            )
-            shouldThrow<NoSuchElementException> { tx { SkattekortRepository.findLatestByPersonId(it, PersonId(1), 2027, adminRole = false) } }
-            tx { SkattekortRepository.findLatestByPersonId(it, PersonId(1), 2026, false) }.id!!.value shouldBe 8732414
-            tx { SkattekortRepository.findLatestByPersonId(it, PersonId(1), 2025, false) }.id!!.value shouldBe 10016224
+        Given("flere skattekort med ulike opprettelsestidspunkt") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, "01010112345"),
+                    aSkattekort(
+                        id = 6986540,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "1058529683",
+                        inntektsaar = 2025,
+                        opprettet = LocalDateTime.parse("2025-12-14T17:16:10.276264"),
+                    ),
+                    aSkattekort(
+                        id = 8732414,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "567677175",
+                        inntektsaar = 2026,
+                        opprettet = LocalDateTime.parse("2025-12-16T19:25:47.520911"),
+                    ),
+                    aSkattekort(
+                        id = 10013248,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "1085419887",
+                        inntektsaar = 2025,
+                        opprettet = LocalDateTime.parse("2025-12-19T15:43:47.381757"),
+                    ),
+                    aSkattekort(
+                        id = 10014205,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "1085419887",
+                        inntektsaar = 2025,
+                        opprettet = LocalDateTime.parse("2025-12-19T15:46:47.541476"),
+                    ),
+                    aSkattekort(
+                        id = 10014992,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "1085419887",
+                        inntektsaar = 2025,
+                        opprettet = LocalDateTime.parse("2025-12-19T15:49:47.685548"),
+                    ),
+                    aSkattekort(
+                        id = 10015752,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "1085419887",
+                        inntektsaar = 2025,
+                        opprettet = LocalDateTime.parse("2025-12-19T15:52:47.833756"),
+                    ),
+                    aSkattekort(
+                        id = 10016224,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "1088125212",
+                        inntektsaar = 2025,
+                        opprettet = LocalDateTime.parse("2025-12-19T16:37:45.751951"),
+                    ),
+                )
+            }
+
+            When("siste skattekort hentes for et gitt inntektsår") {
+                Then("returneres riktig skattekort eller feil når det ikke finnes") {
+                    seedData()
+
+                    shouldThrow<NoSuchElementException> { tx { SkattekortRepository.findLatestByPersonId(it, PersonId(1), 2027, adminRole = false) } }
+                    tx { SkattekortRepository.findLatestByPersonId(it, PersonId(1), 2026, false) }.id!!.value shouldBe 8732414
+                    tx { SkattekortRepository.findLatestByPersonId(it, PersonId(1), 2025, false) }.id!!.value shouldBe 10016224
+                }
+            }
         }
-        test("Hent riktig skattekort når to skattekort har samme opprettet-tidspunkt") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, "01010112345"),
-                aSkattekort(
-                    id = 10015752,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "1085419887",
-                    inntektsaar = 2025,
-                    opprettet = LocalDateTime.parse("2025-12-19T15:52:47.833756"),
-                ),
-                aSkattekort(
-                    id = 10016224,
-                    personId = 1,
-                    utstedtDato = LocalDate.parse("2024-12-05"),
-                    identifikator = "1088125212",
-                    inntektsaar = 2025,
-                    opprettet = LocalDateTime.parse("2025-12-19T15:52:47.833756"),
-                ),
-            )
-            tx { SkattekortRepository.findLatestByPersonId(it, PersonId(1), 2025, false) }.id!!.value shouldBe 10016224
+
+        Given("to skattekort med samme opprettet-tidspunkt") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, "01010112345"),
+                    aSkattekort(
+                        id = 10015752,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "1085419887",
+                        inntektsaar = 2025,
+                        opprettet = LocalDateTime.parse("2025-12-19T15:52:47.833756"),
+                    ),
+                    aSkattekort(
+                        id = 10016224,
+                        personId = 1,
+                        utstedtDato = LocalDate.parse("2024-12-05"),
+                        identifikator = "1088125212",
+                        inntektsaar = 2025,
+                        opprettet = LocalDateTime.parse("2025-12-19T15:52:47.833756"),
+                    ),
+                )
+            }
+
+            When("siste skattekort hentes") {
+                Then("velges riktig skattekort selv om opprettet-tidspunktet er likt") {
+                    seedData()
+
+                    tx { SkattekortRepository.findLatestByPersonId(it, PersonId(1), 2025, false) }.id!!.value shouldBe 10016224
+                }
+            }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortServiceTest.kt
@@ -7,7 +7,7 @@ import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.time.withConstantNow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -22,7 +22,7 @@ import no.nav.sokos.skattekort.utils.TestUtils.tx
 
 @OptIn(ExperimentalAtomicApi::class)
 class SkattekortServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(DbListener)
 
         val mockAuditLogger: AuditLogger = mockk<AuditLogger>()
@@ -41,137 +41,149 @@ class SkattekortServiceTest :
             )
         }
 
-        test("hentSingleSkattekortForEachYear should return the latest skattekort for each year") {
-            withConstantNow(LocalDate.parse("2021-12-24").atStartOfDay()) {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01410100001"),
-                    aSkattekort(id = 1L, personId = 1L, inntektsaar = 2020, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
-                    aSkattekort(id = 2L, personId = 1L, inntektsaar = 2020, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
-                    aSkattekort(id = 3L, personId = 1L, inntektsaar = 2020, resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK),
-                    aDbForskuddstrekk(1L, 3L, ForskuddstrekkType.TABELLKORT.type, Trekkode.LOENN_FRA_NAV, tabellNummer = "8765", prosentSats = 13.37, antMndForTrekk = 4.00),
-                    aSkattekort(id = 4L, personId = 1L, inntektsaar = 2021, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
-                    aSkattekort(id = 5L, personId = 1L, inntektsaar = 2021, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
-                    aSkattekort(id = 6L, personId = 1L, inntektsaar = 2021, resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK),
-                    aDbForskuddstrekk(2L, 6L, ForskuddstrekkType.PROSENTKORT.type, Trekkode.UFOERETRYGD_FRA_NAV, prosentSats = 81.28),
-                    aSkattekort(id = 7L, personId = 1L, inntektsaar = 2022, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
-                    aSkattekort(id = 8L, personId = 1L, inntektsaar = 2022, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
-                    aSkattekort(id = 9L, personId = 1L, inntektsaar = 2022, resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK),
-                    aDbForskuddstrekk(3L, 9L, ForskuddstrekkType.FRIKORT.type, Trekkode.PENSJON_FRA_NAV, frikortbeløp = null),
-                )
+        Given("flere skattekort for ulike år for samme person") {
+            When("siste skattekort for hvert inntektsår hentes") {
+                Then("returneres det nyeste skattekortet for hvert år") {
+                    withConstantNow(LocalDate.parse("2021-12-24").atStartOfDay()) {
+                        databaseHas(
+                            aPerson(1L),
+                            afoedselsnummer(1L, "01410100001"),
+                            aSkattekort(id = 1L, personId = 1L, inntektsaar = 2020, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
+                            aSkattekort(id = 2L, personId = 1L, inntektsaar = 2020, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
+                            aSkattekort(id = 3L, personId = 1L, inntektsaar = 2020, resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK),
+                            aDbForskuddstrekk(1L, 3L, ForskuddstrekkType.TABELLKORT.type, Trekkode.LOENN_FRA_NAV, tabellNummer = "8765", prosentSats = 13.37, antMndForTrekk = 4.00),
+                            aSkattekort(id = 4L, personId = 1L, inntektsaar = 2021, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
+                            aSkattekort(id = 5L, personId = 1L, inntektsaar = 2021, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
+                            aSkattekort(id = 6L, personId = 1L, inntektsaar = 2021, resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK),
+                            aDbForskuddstrekk(2L, 6L, ForskuddstrekkType.PROSENTKORT.type, Trekkode.UFOERETRYGD_FRA_NAV, prosentSats = 81.28),
+                            aSkattekort(id = 7L, personId = 1L, inntektsaar = 2022, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
+                            aSkattekort(id = 8L, personId = 1L, inntektsaar = 2022, resultatForSkattekort = ResultatForSkattekort.IkkeSkattekort),
+                            aSkattekort(id = 9L, personId = 1L, inntektsaar = 2022, resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK),
+                            aDbForskuddstrekk(3L, 9L, ForskuddstrekkType.FRIKORT.type, Trekkode.PENSJON_FRA_NAV, frikortbeløp = null),
+                        )
 
-                val skattekort = skattekortService.getSkattekort("01410100001").get()
-                skattekort shouldNotBeNull {
-                    size shouldBe 9
-                }
-                val onlyLastSkattekort = skattekortService.getSingleSkattekortForEachYear("01410100001").get()
-                onlyLastSkattekort.shouldBeFunctionallyEquivalentTo(
-                    listOf(
-                        aDomainSkattekort(
-                            inntektsaar = 2022,
-                            resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
-                            forskuddstrekk = Frikort(trekkode = Trekkode.PENSJON_FRA_NAV, frikortBeloep = null),
-                            personId = 1L,
-                        ),
-                        aDomainSkattekort(
-                            inntektsaar = 2021,
-                            resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
-                            forskuddstrekk = Prosentkort(trekkode = Trekkode.UFOERETRYGD_FRA_NAV, prosentSats = BigDecimal("81.28")),
-                            personId = 1L,
-                        ),
-                        aDomainSkattekort(
-                            inntektsaar = 2020,
-                            resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
-                            forskuddstrekk =
-                                Tabellkort(
-                                    trekkode = Trekkode.LOENN_FRA_NAV,
-                                    tabellNummer = "8765",
-                                    prosentSats = BigDecimal("13.37"),
-                                    antallMndForTrekk = BigDecimal("4.0"),
+                        val skattekort = skattekortService.getSkattekort("01410100001").get()
+                        skattekort shouldNotBeNull {
+                            size shouldBe 9
+                        }
+                        val onlyLastSkattekort = skattekortService.getSingleSkattekortForEachYear("01410100001").get()
+                        onlyLastSkattekort.shouldBeFunctionallyEquivalentTo(
+                            listOf(
+                                aDomainSkattekort(
+                                    inntektsaar = 2022,
+                                    resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
+                                    forskuddstrekk = Frikort(trekkode = Trekkode.PENSJON_FRA_NAV, frikortBeloep = null),
+                                    personId = 1L,
                                 ),
-                            personId = 1L,
-                        ),
-                    ),
-                )
+                                aDomainSkattekort(
+                                    inntektsaar = 2021,
+                                    resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
+                                    forskuddstrekk = Prosentkort(trekkode = Trekkode.UFOERETRYGD_FRA_NAV, prosentSats = BigDecimal("81.28")),
+                                    personId = 1L,
+                                ),
+                                aDomainSkattekort(
+                                    inntektsaar = 2020,
+                                    resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
+                                    forskuddstrekk =
+                                        Tabellkort(
+                                            trekkode = Trekkode.LOENN_FRA_NAV,
+                                            tabellNummer = "8765",
+                                            prosentSats = BigDecimal("13.37"),
+                                            antallMndForTrekk = BigDecimal("4.0"),
+                                        ),
+                                    personId = 1L,
+                                ),
+                            ),
+                        )
+                    }
+                }
             }
         }
 
-        test("deleteSkattekortForYear should delete all rows for target year in chunks and keep other years untouched") {
+        Given("mange skattekortrader for ett år og noen rader for et annet år") {
             val yearToDelete = 2025
             val yearToKeep = 2026
-
             val keepIds = listOf(50001L, 50002L, 50003L)
-            val skattekortId = AtomicLong(0L)
-            val rowsForDeleteYear =
-                (1L..10005L).flatMap {
-                    var id = skattekortId.incrementAndFetch()
-                    listOf(
-                        aSkattekort(
-                            id = id,
-                            personId = 1L,
-                            inntektsaar = yearToDelete,
-                            identifikator = "delete-$id",
-                        ),
-                        aSkattekort(
-                            id = skattekortId.incrementAndFetch(),
-                            personId = 1L,
-                            inntektsaar = yearToDelete,
-                            identifikator = "delete-$id",
-                            generertFra = id,
-                        ),
-                        aForskuddstrekk(
-                            skattekortId = id,
-                            type =
-                                Prosentkort(
-                                    trekkode = Trekkode.LOENN_FRA_NAV,
-                                    prosentSats = BigDecimal.valueOf(25.0),
-                                ),
-                            trekkode = Trekkode.LOENN_FRA_NAV,
-                            prosentSats = 25.0,
-                        ),
-                        aTilleggsopplysning(
-                            skattekortId = id,
-                            opplysning = Tilleggsopplysning.OPPHOLD_I_TILTAKSSONE,
-                        ),
-                        aSkattekortData(
-                            dataMottatt = """{"identifikator":"delete-$id"}""",
-                            inntektsaar = yearToDelete,
-                            fnr = "01410100001",
-                            skattekortId = id,
-                        ),
-                    )
+
+            fun seedData() {
+                val skattekortId = AtomicLong(0L)
+                val rowsForDeleteYear =
+                    (1L..10005L).flatMap {
+                        var id = skattekortId.incrementAndFetch()
+                        listOf(
+                            aSkattekort(
+                                id = id,
+                                personId = 1L,
+                                inntektsaar = yearToDelete,
+                                identifikator = "delete-$id",
+                            ),
+                            aSkattekort(
+                                id = skattekortId.incrementAndFetch(),
+                                personId = 1L,
+                                inntektsaar = yearToDelete,
+                                identifikator = "delete-$id",
+                                generertFra = id,
+                            ),
+                            aForskuddstrekk(
+                                skattekortId = id,
+                                type =
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal.valueOf(25.0),
+                                    ),
+                                trekkode = Trekkode.LOENN_FRA_NAV,
+                                prosentSats = 25.0,
+                            ),
+                            aTilleggsopplysning(
+                                skattekortId = id,
+                                opplysning = Tilleggsopplysning.OPPHOLD_I_TILTAKSSONE,
+                            ),
+                            aSkattekortData(
+                                dataMottatt = """{"identifikator":"delete-$id"}""",
+                                inntektsaar = yearToDelete,
+                                fnr = "01410100001",
+                                skattekortId = id,
+                            ),
+                        )
+                    }
+
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, "01410100001"),
+                    rowsForDeleteYear.joinToString("\n"),
+                    aSkattekort(
+                        id = keepIds[0],
+                        personId = 1L,
+                        inntektsaar = yearToKeep,
+                        identifikator = "keep-${keepIds[0]}",
+                    ),
+                    aSkattekort(
+                        id = keepIds[1],
+                        personId = 1L,
+                        inntektsaar = yearToKeep,
+                        identifikator = "keep-${keepIds[1]}",
+                    ),
+                    aSkattekort(
+                        id = keepIds[2],
+                        personId = 1L,
+                        inntektsaar = yearToKeep,
+                        identifikator = "keep-${keepIds[2]}",
+                    ),
+                )
+            }
+
+            When("skattekort for et inntektsår slettes") {
+                Then("slettes radene i chunks uten å påvirke andre år") {
+                    seedData()
+
+                    tx { SkattekortRepository.getAllIdByInntektsaar(it, yearToDelete) }.size shouldBe 20010
+                    tx { SkattekortRepository.getAllIdByInntektsaar(it, yearToKeep) } shouldBe keepIds
+
+                    skattekortService.deleteSkattekortForYear(yearToDelete)
+
+                    tx { SkattekortRepository.getAllIdByInntektsaar(it, yearToDelete) } shouldBe emptyList()
+                    tx { SkattekortRepository.getAllIdByInntektsaar(it, yearToKeep) } shouldBe keepIds
                 }
-
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, "01410100001"),
-                rowsForDeleteYear.joinToString("\n"),
-                aSkattekort(
-                    id = keepIds[0],
-                    personId = 1L,
-                    inntektsaar = yearToKeep,
-                    identifikator = "keep-${keepIds[0]}",
-                ),
-                aSkattekort(
-                    id = keepIds[1],
-                    personId = 1L,
-                    inntektsaar = yearToKeep,
-                    identifikator = "keep-${keepIds[1]}",
-                ),
-                aSkattekort(
-                    id = keepIds[2],
-                    personId = 1L,
-                    inntektsaar = yearToKeep,
-                    identifikator = "keep-${keepIds[2]}",
-                ),
-            )
-
-            tx { SkattekortRepository.getAllIdByInntektsaar(it, yearToDelete) }.size shouldBe 20010
-            tx { SkattekortRepository.getAllIdByInntektsaar(it, yearToKeep) } shouldBe keepIds
-
-            skattekortService.deleteSkattekortForYear(yearToDelete)
-
-            tx { SkattekortRepository.getAllIdByInntektsaar(it, yearToDelete) } shouldBe emptyList()
-            tx { SkattekortRepository.getAllIdByInntektsaar(it, yearToKeep) } shouldBe keepIds
+            }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/skattekort/SyntetiseringTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/skattekort/SyntetiseringTest.kt
@@ -5,7 +5,7 @@ import java.math.BigDecimal
 import kotlin.time.ExperimentalTime
 
 import io.kotest.assertions.assertSoftly
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
@@ -15,9 +15,9 @@ import no.nav.sokos.skattekort.person.PersonId
 
 @OptIn(ExperimentalTime::class)
 class SyntetiseringTest :
-    FunSpec({
-        test("Lag frikort for ikke trekkpliktige") {
-            val sk =
+    BehaviorSpec({
+        Given("en bruker som ikke er trekkpliktig") {
+            fun ikkeTrekkpliktigSkattekort() =
                 Skattekort(
                     resultatForSkattekort = ResultatForSkattekort.IkkeTrekkplikt,
                     personId = PersonId(1),
@@ -26,294 +26,314 @@ class SyntetiseringTest :
                     inntektsaar = 2025,
                     kilde = "BOGUS",
                 )
-            val resultat: Pair<Skattekort, String>? =
-                Syntetisering.evtSyntetiserSkattekort(
-                    skattekort = sk,
-                    id =
-                        SkattekortId(
-                            1,
-                        ),
-                )
-            assertSoftly {
-                resultat shouldNotBeNull {
-                    first.forskuddstrekkList shouldContainExactly
-                        listOf(
-                            Frikort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                frikortBeloep = null,
-                            ),
-                            Frikort(
-                                trekkode = Trekkode.PENSJON_FRA_NAV,
-                                frikortBeloep = null,
-                            ),
-                            Frikort(
-                                trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
-                                frikortBeloep = null,
-                            ),
+
+            When("skattekortet syntetiseres") {
+                Then("lages frikort for relevante trekkoder") {
+                    val sk = ikkeTrekkpliktigSkattekort()
+                    val resultat: Pair<Skattekort, String>? =
+                        Syntetisering.evtSyntetiserSkattekort(
+                            skattekort = sk,
+                            id =
+                                SkattekortId(
+                                    1,
+                                ),
                         )
-                }
-            }
-        }
-        test("Lag default-trekk for svalbard") {
-            val sk =
-                Skattekort(
-                    resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
-                    personId = PersonId(1),
-                    utstedtDato = null,
-                    identifikator = null,
-                    inntektsaar = 2025,
-                    kilde = "BOGUS",
-                    tilleggsopplysningList = listOf(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD),
-                )
-            val resultat: Pair<Skattekort, String>? =
-                Syntetisering.evtSyntetiserSkattekort(
-                    skattekort = sk,
-                    id =
-                        SkattekortId(
-                            1,
-                        ),
-                )
-            assertSoftly {
-                resultat shouldNotBeNull {
-                    first.forskuddstrekkList shouldContainExactly
-                        listOf<Forskuddstrekk>(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("15.70"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.PENSJON_FRA_NAV,
-                                prosentSats = BigDecimal("13.10"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
-                                prosentSats = BigDecimal("15.70"),
-                            ),
-                        )
-                }
-            }
-        }
-        test("Lag default-trekk for svalbard med oppdaterte satser for 2026") {
-            val sk =
-                Skattekort(
-                    resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
-                    personId = PersonId(1),
-                    utstedtDato = null,
-                    identifikator = null,
-                    inntektsaar = 2026,
-                    kilde = "BOGUS",
-                    tilleggsopplysningList = listOf(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD),
-                )
-            val resultat: Pair<Skattekort, String>? =
-                Syntetisering.evtSyntetiserSkattekort(
-                    skattekort = sk,
-                    id =
-                        SkattekortId(
-                            1,
-                        ),
-                )
-            assertSoftly {
-                resultat shouldNotBeNull {
-                    first.forskuddstrekkList shouldContainExactly
-                        listOf<Forskuddstrekk>(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("15.60"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.PENSJON_FRA_NAV,
-                                prosentSats = BigDecimal("13.10"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
-                                prosentSats = BigDecimal("15.60"),
-                            ),
-                        )
+                    assertSoftly {
+                        resultat shouldNotBeNull {
+                            first.forskuddstrekkList shouldContainExactly
+                                listOf(
+                                    Frikort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        frikortBeloep = null,
+                                    ),
+                                    Frikort(
+                                        trekkode = Trekkode.PENSJON_FRA_NAV,
+                                        frikortBeloep = null,
+                                    ),
+                                    Frikort(
+                                        trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
+                                        frikortBeloep = null,
+                                    ),
+                                )
+                        }
+                    }
                 }
             }
         }
 
-        test("Ikke rør skattekort for kildeskatt pensjon") {
-            val sk =
+        Given("skattekort med opphold på Svalbard") {
+            fun svalbardSkattekort(inntektsaar: Int) =
                 Skattekort(
                     resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
                     personId = PersonId(1),
                     utstedtDato = null,
                     identifikator = null,
-                    inntektsaar = 2025,
+                    inntektsaar = inntektsaar,
                     kilde = "BOGUS",
-                    forskuddstrekkList =
-                        listOf(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.PENSJON_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                        ),
-                    tilleggsopplysningList = listOf(Tilleggsopplysning.KILDESKATT_PAA_PENSJON),
+                    tilleggsopplysningList = listOf(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD),
                 )
-            val resultat: Pair<Skattekort, String>? =
-                Syntetisering.evtSyntetiserSkattekort(
-                    skattekort = sk,
-                    id =
-                        SkattekortId(
-                            1,
-                        ),
-                )
-            assertSoftly {
-                resultat.shouldBeNull()
-            }
-        }
-        test("Fyll inn manglende PENSJON_FRA_NAV for kildeskatt, ikke rør resten") {
-            val sk =
-                Skattekort(
-                    resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
-                    personId = PersonId(1),
-                    utstedtDato = null,
-                    identifikator = null,
-                    inntektsaar = 2025,
-                    kilde = "BOGUS",
-                    forskuddstrekkList =
-                        listOf(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                        ),
-                    tilleggsopplysningList = listOf(Tilleggsopplysning.KILDESKATT_PAA_PENSJON),
-                )
-            val resultat: Pair<Skattekort, String>? =
-                Syntetisering.evtSyntetiserSkattekort(
-                    skattekort = sk,
-                    id =
-                        SkattekortId(
-                            1,
-                        ),
-                )
-            assertSoftly {
-                resultat shouldNotBeNull {
-                    first.forskuddstrekkList shouldContainAll
-                        listOf(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.PENSJON_FRA_NAV,
-                                prosentSats = BigDecimal("15.00"),
-                            ),
+
+            When("skattekortet gjelder 2025") {
+                Then("lages default-trekk for Svalbard") {
+                    val sk = svalbardSkattekort(2025)
+                    val resultat: Pair<Skattekort, String>? =
+                        Syntetisering.evtSyntetiserSkattekort(
+                            skattekort = sk,
+                            id =
+                                SkattekortId(
+                                    1,
+                                ),
                         )
+                    assertSoftly {
+                        resultat shouldNotBeNull {
+                            first.forskuddstrekkList shouldContainExactly
+                                listOf<Forskuddstrekk>(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("15.70"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.PENSJON_FRA_NAV,
+                                        prosentSats = BigDecimal("13.10"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
+                                        prosentSats = BigDecimal("15.70"),
+                                    ),
+                                )
+                        }
+                    }
+                }
+            }
+
+            When("skattekortet gjelder 2026") {
+                Then("lages default-trekk med oppdaterte satser for Svalbard") {
+                    val sk = svalbardSkattekort(2026)
+                    val resultat: Pair<Skattekort, String>? =
+                        Syntetisering.evtSyntetiserSkattekort(
+                            skattekort = sk,
+                            id =
+                                SkattekortId(
+                                    1,
+                                ),
+                        )
+                    assertSoftly {
+                        resultat shouldNotBeNull {
+                            first.forskuddstrekkList shouldContainExactly
+                                listOf<Forskuddstrekk>(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("15.60"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.PENSJON_FRA_NAV,
+                                        prosentSats = BigDecimal("13.10"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
+                                        prosentSats = BigDecimal("15.60"),
+                                    ),
+                                )
+                        }
+                    }
                 }
             }
         }
-        test("Fyll inn manglende PENSJON_FRA_NAV og UFOERETRYGD_FRA_NAV for kildeskatt, ikke rør resten") {
-            val sk =
-                Skattekort(
-                    resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
-                    personId = PersonId(1),
-                    utstedtDato = null,
-                    identifikator = null,
-                    inntektsaar = 2025,
-                    kilde = "BOGUS",
-                    forskuddstrekkList =
-                        listOf(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                        ),
-                    tilleggsopplysningList = listOf(Tilleggsopplysning.KILDESKATT_PAA_PENSJON),
-                )
-            val resultat: Pair<Skattekort, String>? =
-                Syntetisering.evtSyntetiserSkattekort(
-                    skattekort = sk,
-                    id =
-                        SkattekortId(
-                            1,
-                        ),
-                )
-            assertSoftly {
-                resultat shouldNotBeNull {
-                    first.forskuddstrekkList shouldContainAll
-                        listOf(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
-                                prosentSats = BigDecimal("15.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.PENSJON_FRA_NAV,
-                                prosentSats = BigDecimal("15.00"),
-                            ),
+
+        Given("skattekort med kildeskatt på pensjon") {
+            When("skattekortet allerede har alle nødvendige trekkoder") {
+                Then("skal skattekortet ikke røres") {
+                    val sk =
+                        Skattekort(
+                            resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
+                            personId = PersonId(1),
+                            utstedtDato = null,
+                            identifikator = null,
+                            inntektsaar = 2025,
+                            kilde = "BOGUS",
+                            forskuddstrekkList =
+                                listOf(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.PENSJON_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                ),
+                            tilleggsopplysningList = listOf(Tilleggsopplysning.KILDESKATT_PAA_PENSJON),
                         )
+                    val resultat: Pair<Skattekort, String>? =
+                        Syntetisering.evtSyntetiserSkattekort(
+                            skattekort = sk,
+                            id =
+                                SkattekortId(
+                                    1,
+                                ),
+                        )
+                    assertSoftly {
+                        resultat.shouldBeNull()
+                    }
                 }
             }
-        }
-        test("Fyll inn manglende UFOERETRYGD_FRA_NAV for kildeskatt, ikke rør resten") {
-            val sk =
-                Skattekort(
-                    resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
-                    personId = PersonId(1),
-                    utstedtDato = null,
-                    identifikator = null,
-                    inntektsaar = 2025,
-                    kilde = "BOGUS",
-                    forskuddstrekkList =
-                        listOf(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.PENSJON_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                        ),
-                    tilleggsopplysningList = listOf(Tilleggsopplysning.KILDESKATT_PAA_PENSJON),
-                )
-            val resultat: Pair<Skattekort, String>? =
-                Syntetisering.evtSyntetiserSkattekort(
-                    skattekort = sk,
-                    id =
-                        SkattekortId(
-                            1,
-                        ),
-                )
-            assertSoftly {
-                resultat shouldNotBeNull {
-                    first.forskuddstrekkList shouldContainAll
-                        listOf(
-                            Prosentkort(
-                                trekkode = Trekkode.LOENN_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
-                                prosentSats = BigDecimal("15.00"),
-                            ),
-                            Prosentkort(
-                                trekkode = Trekkode.PENSJON_FRA_NAV,
-                                prosentSats = BigDecimal("200.00"),
-                            ),
+
+            When("PENSJON_FRA_NAV mangler") {
+                Then("fylles manglende trekkode inn uten å endre resten") {
+                    val sk =
+                        Skattekort(
+                            resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
+                            personId = PersonId(1),
+                            utstedtDato = null,
+                            identifikator = null,
+                            inntektsaar = 2025,
+                            kilde = "BOGUS",
+                            forskuddstrekkList =
+                                listOf(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                ),
+                            tilleggsopplysningList = listOf(Tilleggsopplysning.KILDESKATT_PAA_PENSJON),
                         )
+                    val resultat: Pair<Skattekort, String>? =
+                        Syntetisering.evtSyntetiserSkattekort(
+                            skattekort = sk,
+                            id =
+                                SkattekortId(
+                                    1,
+                                ),
+                        )
+                    assertSoftly {
+                        resultat shouldNotBeNull {
+                            first.forskuddstrekkList shouldContainAll
+                                listOf(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.PENSJON_FRA_NAV,
+                                        prosentSats = BigDecimal("15.00"),
+                                    ),
+                                )
+                        }
+                    }
+                }
+            }
+
+            When("PENSJON_FRA_NAV og UFOERETRYGD_FRA_NAV mangler") {
+                Then("fylles begge manglende trekkoder inn uten å endre resten") {
+                    val sk =
+                        Skattekort(
+                            resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
+                            personId = PersonId(1),
+                            utstedtDato = null,
+                            identifikator = null,
+                            inntektsaar = 2025,
+                            kilde = "BOGUS",
+                            forskuddstrekkList =
+                                listOf(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                ),
+                            tilleggsopplysningList = listOf(Tilleggsopplysning.KILDESKATT_PAA_PENSJON),
+                        )
+                    val resultat: Pair<Skattekort, String>? =
+                        Syntetisering.evtSyntetiserSkattekort(
+                            skattekort = sk,
+                            id =
+                                SkattekortId(
+                                    1,
+                                ),
+                        )
+                    assertSoftly {
+                        resultat shouldNotBeNull {
+                            first.forskuddstrekkList shouldContainAll
+                                listOf(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
+                                        prosentSats = BigDecimal("15.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.PENSJON_FRA_NAV,
+                                        prosentSats = BigDecimal("15.00"),
+                                    ),
+                                )
+                        }
+                    }
+                }
+            }
+
+            When("UFOERETRYGD_FRA_NAV mangler") {
+                Then("fylles manglende trekkode inn uten å endre resten") {
+                    val sk =
+                        Skattekort(
+                            resultatForSkattekort = ResultatForSkattekort.SkattekortopplysningerOK,
+                            personId = PersonId(1),
+                            utstedtDato = null,
+                            identifikator = null,
+                            inntektsaar = 2025,
+                            kilde = "BOGUS",
+                            forskuddstrekkList =
+                                listOf(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.PENSJON_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                ),
+                            tilleggsopplysningList = listOf(Tilleggsopplysning.KILDESKATT_PAA_PENSJON),
+                        )
+                    val resultat: Pair<Skattekort, String>? =
+                        Syntetisering.evtSyntetiserSkattekort(
+                            skattekort = sk,
+                            id =
+                                SkattekortId(
+                                    1,
+                                ),
+                        )
+                    assertSoftly {
+                        resultat shouldNotBeNull {
+                            first.forskuddstrekkList shouldContainAll
+                                listOf(
+                                    Prosentkort(
+                                        trekkode = Trekkode.LOENN_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.UFOERETRYGD_FRA_NAV,
+                                        prosentSats = BigDecimal("15.00"),
+                                    ),
+                                    Prosentkort(
+                                        trekkode = Trekkode.PENSJON_FRA_NAV,
+                                        prosentSats = BigDecimal("200.00"),
+                                    ),
+                                )
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/no/nav/sokos/skattekort/skattekortbestilling/BestillingsbatchServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/skattekortbestilling/BestillingsbatchServiceTest.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.datatest.withData
 import io.kotest.extensions.time.withConstantNow
 import io.kotest.inspectors.forAll
@@ -44,7 +44,7 @@ import no.nav.sokos.skattekort.utils.DBTestUtils
 import no.nav.sokos.skattekort.utils.TestUtils.tx
 
 class BestillingsbatchServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(DbListener)
 
         val skatteetatenClient = mockk<SkatteetatenClient>()
@@ -57,158 +57,312 @@ class BestillingsbatchServiceTest :
             )
         }
 
-        test("bestillSkattekort - Hvis det er bestillinger for neste år, ikke plukk opp før 15.12.") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                aPerson(2L),
-                afoedselsnummer(personId = 2L, fnr = "02020200002"),
-                aPerson(3L),
-                afoedselsnummer(personId = 3L, fnr = "03030300003"),
-                aBestilling(1L, "01010100001", 2025, null),
-                aBestilling(2L, "02020200002", 2026, null),
-                aBestilling(3L, "03030300003", 2026, null),
-            )
-
-            coEvery { skatteetatenClient.bestillSkattekort(any()) } returns
-                okBestillSkattekortResponse("ref1") andThen
-                okBestillSkattekortResponse("ref2")
-
-            withConstantNow(LocalDateTime.parse("2025-12-14T00:00:00")) {
-                // Kaller to ganger for å sjekke at den ikke plukker opp 2026 på andre kall
-                bestillingsbatchService.bestillSkattekort()
-                bestillingsbatchService.bestillSkattekort()
-
-                val bestillings: List<Bestilling> = tx(DBTestUtils::getAllBestilling)
-                val batches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
-
-                batches.size shouldBe 1
-                batches.shouldContainAllIgnoringFields(
-                    listOf(aBatch(id = 1L, status = NY, type = BESTILLING, bestillingsreferanse = "ref1")),
-                    Bestillingsbatch::oppdatert,
-                    Bestillingsbatch::opprettet,
-                    Bestillingsbatch::dataSendt,
-                )
-                batches.first().dataSendt shouldNotBeNull {
-                    this shouldContain "01010100001"
-                    this shouldNotContain "02020200002"
-                    this shouldNotContain "03030300003"
-                }
-
-                bestillings.size shouldBe 3
-                bestillings.shouldContainAllIgnoringFields(
-                    listOf(
-                        Bestilling(
-                            personId = PersonId(1L),
-                            fnr = Personidentifikator("01010100001"),
-                            inntektsaar = 2025,
-                            bestillingsbatchId = BestillingsbatchId(1L),
-                        ),
-                        Bestilling(
-                            personId = PersonId(2L),
-                            fnr = Personidentifikator("02020200002"),
-                            inntektsaar = 2026,
-                            bestillingsbatchId = null,
-                        ),
-                        Bestilling(
-                            personId = PersonId(3L),
-                            fnr = Personidentifikator("03030300003"),
-                            inntektsaar = 2026,
-                            bestillingsbatchId = null,
-                        ),
-                    ),
-                    Bestilling::oppdatert,
-                    Bestilling::id,
-                )
-            }
-
-            withConstantNow(LocalDateTime.parse("2025-12-15T00:00:00")) {
-                bestillingsbatchService.bestillSkattekort()
-
-                val bestillings: List<Bestilling> = tx(DBTestUtils::getAllBestilling)
-                val batches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
-
-                batches.size shouldBe 2
-                batches.shouldContainAllIgnoringFields(
-                    listOf(
-                        aBatch(id = 1L, status = NY, type = BESTILLING, bestillingsreferanse = "ref1"),
-                        aBatch(id = 2L, status = NY, type = BESTILLING, bestillingsreferanse = "ref2"),
-                    ),
-                    Bestillingsbatch::oppdatert,
-                    Bestillingsbatch::opprettet,
-                    Bestillingsbatch::id,
-                    Bestillingsbatch::dataSendt,
-                )
-                batches.first { it.id?.id == 1L }.dataSendt shouldNotBeNull {
-                    this shouldContain "01010100001"
-                    this shouldNotContain "02020200002"
-                    this shouldNotContain "03030300003"
-                }
-                batches.first { it.id?.id == 2L }.dataSendt shouldNotBeNull {
-                    this shouldNotContain "01010100001"
-                    this shouldContain "02020200002"
-                    this shouldContain "03030300003"
-                }
-
-                bestillings.size shouldBe 3
-                bestillings.shouldContainAllIgnoringFields(
-                    listOf(
-                        Bestilling(
-                            personId = PersonId(1L),
-                            fnr = Personidentifikator("01010100001"),
-                            inntektsaar = 2025,
-                            bestillingsbatchId = BestillingsbatchId(1L),
-                        ),
-                        Bestilling(
-                            personId = PersonId(2L),
-                            fnr = Personidentifikator("02020200002"),
-                            inntektsaar = 2026,
-                            bestillingsbatchId = BestillingsbatchId(2L),
-                        ),
-                        Bestilling(
-                            personId = PersonId(3L),
-                            fnr = Personidentifikator("03030300003"),
-                            inntektsaar = 2026,
-                            bestillingsbatchId = BestillingsbatchId(2L),
-                        ),
-                    ),
-                    Bestilling::oppdatert,
-                    Bestilling::id,
-                )
-            }
-        }
-
-        test("bestillOppdaterteSkattekort - Når vi gjør et kall med tom database i midten av året skal det opprettes én batch") {
-            withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
-                coEvery { skatteetatenClient.bestillSkattekort(any()) } returns okBestillSkattekortResponse("some-bestillings-ref")
+        Given("bestillinger for inneværende og neste år før 15. desember") {
+            When("skattekort bestilles før grensen for neste år") {
                 databaseHas(
                     aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
                     aPerson(2L),
-                    afoedselsnummer(2L, "02020200002"),
+                    afoedselsnummer(personId = 2L, fnr = "02020200002"),
                     aPerson(3L),
-                    afoedselsnummer(3L, "03030300003"),
+                    afoedselsnummer(personId = 3L, fnr = "03030300003"),
+                    aBestilling(1L, "01010100001", 2025, null),
+                    aBestilling(2L, "02020200002", 2026, null),
+                    aBestilling(3L, "03030300003", 2026, null),
                 )
 
-                bestillingsbatchService.bestillOppdaterteSkattekort()
+                coEvery { skatteetatenClient.bestillSkattekort(any()) } returns
+                    okBestillSkattekortResponse("ref1") andThen
+                    okBestillSkattekortResponse("ref2")
 
-                val batches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
+                withConstantNow(LocalDateTime.parse("2025-12-14T00:00:00")) {
+                    bestillingsbatchService.bestillSkattekort()
+                    bestillingsbatchService.bestillSkattekort()
 
-                batches.shouldBeFunctionallyEquivalentTo(
-                    listOf(
-                        aBatch(id = 1L, bestillingsreferanse = "some-bestillings-ref", status = NY, type = OPPDATERING),
-                    ),
+                    val bestillings: List<Bestilling> = tx(DBTestUtils::getAllBestilling)
+                    val batches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
+
+                    Then("kun inneværende år legges i batch før 15. desember") {
+                        batches.size shouldBe 1
+                        batches.shouldContainAllIgnoringFields(
+                            listOf(aBatch(id = 1L, status = NY, type = BESTILLING, bestillingsreferanse = "ref1")),
+                            Bestillingsbatch::oppdatert,
+                            Bestillingsbatch::opprettet,
+                            Bestillingsbatch::dataSendt,
+                        )
+                        batches.first().dataSendt shouldNotBeNull {
+                            this shouldContain "01010100001"
+                            this shouldNotContain "02020200002"
+                            this shouldNotContain "03030300003"
+                        }
+
+                        bestillings.size shouldBe 3
+                        bestillings.shouldContainAllIgnoringFields(
+                            listOf(
+                                Bestilling(
+                                    personId = PersonId(1L),
+                                    fnr = Personidentifikator("01010100001"),
+                                    inntektsaar = 2025,
+                                    bestillingsbatchId = BestillingsbatchId(1L),
+                                ),
+                                Bestilling(
+                                    personId = PersonId(2L),
+                                    fnr = Personidentifikator("02020200002"),
+                                    inntektsaar = 2026,
+                                    bestillingsbatchId = null,
+                                ),
+                                Bestilling(
+                                    personId = PersonId(3L),
+                                    fnr = Personidentifikator("03030300003"),
+                                    inntektsaar = 2026,
+                                    bestillingsbatchId = null,
+                                ),
+                            ),
+                            Bestilling::oppdatert,
+                            Bestilling::id,
+                        )
+                    }
+                }
+            }
+
+            When("skattekort bestilles fra og med 15. desember") {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    aPerson(2L),
+                    afoedselsnummer(personId = 2L, fnr = "02020200002"),
+                    aPerson(3L),
+                    afoedselsnummer(personId = 3L, fnr = "03030300003"),
+                    aBestilling(1L, "01010100001", 2025, null),
+                    aBestilling(2L, "02020200002", 2026, null),
+                    aBestilling(3L, "03030300003", 2026, null),
                 )
+
+                coEvery { skatteetatenClient.bestillSkattekort(any()) } returns
+                    okBestillSkattekortResponse("ref1") andThen
+                    okBestillSkattekortResponse("ref2")
+
+                withConstantNow(LocalDateTime.parse("2025-12-15T00:00:00")) {
+                    withConstantNow(LocalDateTime.parse("2025-12-14T00:00:00")) {
+                        bestillingsbatchService.bestillSkattekort()
+                        bestillingsbatchService.bestillSkattekort()
+                    }
+                    bestillingsbatchService.bestillSkattekort()
+
+                    val bestillings: List<Bestilling> = tx(DBTestUtils::getAllBestilling)
+                    val batches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
+
+                    Then("det opprettes batcher for både inneværende og neste år") {
+                        batches.size shouldBe 2
+                        batches.shouldContainAllIgnoringFields(
+                            listOf(
+                                aBatch(id = 1L, status = NY, type = BESTILLING, bestillingsreferanse = "ref1"),
+                                aBatch(id = 2L, status = NY, type = BESTILLING, bestillingsreferanse = "ref2"),
+                            ),
+                            Bestillingsbatch::oppdatert,
+                            Bestillingsbatch::opprettet,
+                            Bestillingsbatch::id,
+                            Bestillingsbatch::dataSendt,
+                        )
+                        batches.first { it.id?.id == 1L }.dataSendt shouldNotBeNull {
+                            this shouldContain "01010100001"
+                            this shouldNotContain "02020200002"
+                            this shouldNotContain "03030300003"
+                        }
+                        batches.first { it.id?.id == 2L }.dataSendt shouldNotBeNull {
+                            this shouldNotContain "01010100001"
+                            this shouldContain "02020200002"
+                            this shouldContain "03030300003"
+                        }
+
+                        bestillings.size shouldBe 3
+                        bestillings.shouldContainAllIgnoringFields(
+                            listOf(
+                                Bestilling(
+                                    personId = PersonId(1L),
+                                    fnr = Personidentifikator("01010100001"),
+                                    inntektsaar = 2025,
+                                    bestillingsbatchId = BestillingsbatchId(1L),
+                                ),
+                                Bestilling(
+                                    personId = PersonId(2L),
+                                    fnr = Personidentifikator("02020200002"),
+                                    inntektsaar = 2026,
+                                    bestillingsbatchId = BestillingsbatchId(2L),
+                                ),
+                                Bestilling(
+                                    personId = PersonId(3L),
+                                    fnr = Personidentifikator("03030300003"),
+                                    inntektsaar = 2026,
+                                    bestillingsbatchId = BestillingsbatchId(2L),
+                                ),
+                            ),
+                            Bestilling::oppdatert,
+                            Bestilling::id,
+                        )
+                    }
+                }
             }
         }
 
-        test("bestillOppdaterteSkattekort - Når vi gjør et kall med tom database i slutten av desember skal det opprettes to batcher") {
-            withConstantNow(LocalDateTime.parse("2025-12-20T00:00:00")) {
-                coEvery { skatteetatenClient.bestillSkattekort(any()) } returnsMany
-                    listOf(
-                        okBestillSkattekortResponse("some-bestillings-ref1"),
-                        okBestillSkattekortResponse("some-bestillings-ref2"),
+        Given("en tom database midt i året med personer som kan bestilles oppdaterte skattekort for") {
+            When("oppdaterte skattekort bestilles") {
+                withConstantNow(LocalDateTime.parse("2025-04-12T00:00:00")) {
+                    coEvery { skatteetatenClient.bestillSkattekort(any()) } returns okBestillSkattekortResponse("some-bestillings-ref")
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aPerson(2L),
+                        afoedselsnummer(2L, "02020200002"),
+                        aPerson(3L),
+                        afoedselsnummer(3L, "03030300003"),
                     )
+
+                    bestillingsbatchService.bestillOppdaterteSkattekort()
+
+                    val batches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
+
+                    Then("det opprettes én oppdateringsbatch") {
+                        batches.shouldBeFunctionallyEquivalentTo(
+                            listOf(
+                                aBatch(id = 1L, bestillingsreferanse = "some-bestillings-ref", status = NY, type = OPPDATERING),
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        Given("en tom database i slutten av desember med personer som kan bestilles oppdaterte skattekort for") {
+            When("oppdaterte skattekort bestilles") {
+                withConstantNow(LocalDateTime.parse("2025-12-20T00:00:00")) {
+                    coEvery { skatteetatenClient.bestillSkattekort(any()) } returnsMany
+                        listOf(
+                            okBestillSkattekortResponse("some-bestillings-ref1"),
+                            okBestillSkattekortResponse("some-bestillings-ref2"),
+                        )
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aPerson(2L),
+                        afoedselsnummer(2L, "02020200002"),
+                        aPerson(3L),
+                        afoedselsnummer(3L, "03030300003"),
+                    )
+
+                    bestillingsbatchService.bestillOppdaterteSkattekort()
+
+                    val batches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
+
+                    Then("det opprettes to oppdateringsbatcher") {
+                        assertSoftly {
+                            batches shouldNotBeNull {
+                                size shouldBe 2
+                                first() shouldNotBeNull {
+                                    status shouldBe NY
+
+                                    type shouldBe OPPDATERING
+                                    bestillingsreferanse shouldBe "some-bestillings-ref1"
+                                }
+                                elementAt(1) shouldNotBeNull {
+                                    status shouldBe NY
+                                    type shouldBe OPPDATERING
+                                    bestillingsreferanse shouldBe "some-bestillings-ref2"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("bestillingsbatcher med og uten JSON-felter i ulike statuser") {
+            When("ufullstendige batcher hentes uten JSON-feltene") {
+                databaseHas(
+                    aBestillingsbatchWithJson(
+                        id = 1L,
+                        ref = "BR1337",
+                        status = NY,
+                        dataSendt = """{"sendt":"hei"}""",
+                        dataMottatt = null,
+                    ),
+                    aBestillingsbatchWithJson(
+                        id = 2L,
+                        ref = "BR13373",
+                        status = RETRY,
+                        dataSendt = """{"sendt":"x"}""",
+                        dataMottatt = null,
+                    ),
+                    aBestillingsbatchWithJson(
+                        id = 3L,
+                        ref = "BR313373",
+                        status = FEILET,
+                        dataSendt = """{"sendt":"y"}""",
+                        dataMottatt = """{"mottatt":"her har det visst blitt litt surr"}""",
+                    ),
+                    aBestillingsbatchWithJson(
+                        id = 4L,
+                        ref = "BR666",
+                        status = FERDIG,
+                        dataSendt = """{"sendt":"z"}""",
+                        dataMottatt = """{"mottatt":"ok"}""",
+                    ),
+                )
+
+                val dtos = bestillingsbatchService.getIncompleteBestillingsbatchesWithoutJson()
+
+                Then("kun batcher som ikke er ferdige returneres") {
+                    assertSoftly(dtos) {
+                        withClue("Skal kun inneholde batcher som ikke er FERDIG") {
+                            map { it.id } shouldContainExactlyInAnyOrder listOf(1L, 2L, 3L)
+                            forAll { it.status shouldNotBe FERDIG }
+                        }
+                        withClue("dataSendt og dataMottatt skal være null i denne 'lette' responsen") {
+                            forAll {
+                                it.dataSendt.shouldBeNull()
+                                it.dataMottatt.shouldBeNull()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("en bestillingsbatch med status FEILET") {
+            When("rerun kjøres for batchen") {
+                databaseHas(
+                    aBestillingsbatch(id = 1L, ref = "feilet", status = FEILET),
+                )
+
+                val updated = bestillingsbatchService.rerun(1L)
+
+                val batch = tx { BestillingsbatchRepository.findById(it, 1L) }
+
+                Then("batchen settes til RETRY og én rad oppdateres") {
+                    assertSoftly {
+                        updated shouldBe 1
+                        batch.shouldNotBeNull()
+                        batch.status shouldBe RETRY
+                    }
+                }
+            }
+        }
+
+        Given("at bestillingsbatchen som rerun skal kjøres for ikke finnes") {
+            When("rerun kjøres") {
+                val ex =
+                    shouldThrow<IllegalArgumentException> {
+                        bestillingsbatchService.rerun(99999L)
+                    }
+
+                Then("det kastes en IllegalArgumentException med forventet melding") {
+                    ex.message shouldBe "Kunne ikke finne bestillingsbatch med id 99999 for rerun"
+                }
+            }
+        }
+
+        Given("bestillinger både med og uten batch-tilknytning") {
+            When("alle bestillinger hentes") {
                 databaseHas(
                     aPerson(1L),
                     afoedselsnummer(1L, "01010100001"),
@@ -216,187 +370,99 @@ class BestillingsbatchServiceTest :
                     afoedselsnummer(2L, "02020200002"),
                     aPerson(3L),
                     afoedselsnummer(3L, "03030300003"),
+                    aBestillingsbatch(id = 10L, ref = "ref-a", status = NY),
+                    aBestilling(personId = 1L, fnr = "01010100001", inntektsaar = 2025, batchId = 10L),
+                    aBestilling(personId = 2L, fnr = "02020200002", inntektsaar = 2026, batchId = 10L),
+                    aBestilling(personId = 3L, fnr = "03030300003", inntektsaar = 2026, batchId = null),
                 )
 
-                bestillingsbatchService.bestillOppdaterteSkattekort()
+                val bestillinger = bestillingsbatchService.getAllBestillings()
 
-                val batches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
-
-                assertSoftly {
-                    batches shouldNotBeNull {
-                        size shouldBe 2
-                        first() shouldNotBeNull {
-                            status shouldBe NY
-
-                            type shouldBe OPPDATERING
-                            bestillingsreferanse shouldBe "some-bestillings-ref1"
-                        }
-                        elementAt(1) shouldNotBeNull {
-                            status shouldBe NY
-                            type shouldBe OPPDATERING
-                            bestillingsreferanse shouldBe "some-bestillings-ref2"
-                        }
-                    }
+                Then("alle bestillingene returneres uavhengig av batch-tilknytning") {
+                    bestillinger.shouldContainAllIgnoringFields(
+                        listOf(
+                            Bestilling(
+                                personId = PersonId(1L),
+                                fnr = Personidentifikator("01010100001"),
+                                inntektsaar = 2025,
+                                bestillingsbatchId = BestillingsbatchId(10L),
+                            ),
+                            Bestilling(
+                                personId = PersonId(2L),
+                                fnr = Personidentifikator("02020200002"),
+                                inntektsaar = 2026,
+                                bestillingsbatchId = BestillingsbatchId(10L),
+                            ),
+                            Bestilling(
+                                personId = PersonId(3L),
+                                fnr = Personidentifikator("03030300003"),
+                                inntektsaar = 2026,
+                                bestillingsbatchId = null,
+                            ),
+                        ),
+                        Bestilling::id,
+                        Bestilling::oppdatert,
+                    )
                 }
             }
         }
-        test("getIncompleteBestillingsbatchesWithoutJson - returnerer kun ikke-FERDIG og utelater JSON-feltene") {
-            databaseHas(
-                aBestillingsbatchWithJson(
-                    id = 1L,
-                    ref = "BR1337",
-                    status = NY,
-                    dataSendt = """{"sendt":"hei"}""",
-                    dataMottatt = null,
-                ),
-                aBestillingsbatchWithJson(
-                    id = 2L,
-                    ref = "BR13373",
-                    status = RETRY,
-                    dataSendt = """{"sendt":"x"}""",
-                    dataMottatt = null,
-                ),
-                aBestillingsbatchWithJson(
-                    id = 3L,
-                    ref = "BR313373",
-                    status = FEILET,
-                    dataSendt = """{"sendt":"y"}""",
-                    dataMottatt = """{"mottatt":"her har det visst blitt litt surr"}""",
-                ),
-                aBestillingsbatchWithJson(
-                    id = 4L,
-                    ref = "BR666",
-                    status = FERDIG,
-                    dataSendt = """{"sendt":"z"}""",
-                    dataMottatt = """{"mottatt":"ok"}""",
-                ),
-            )
 
-            val dtos = bestillingsbatchService.getIncompleteBestillingsbatchesWithoutJson()
-
-            assertSoftly(dtos) {
-                withClue("Skal kun inneholde batcher som ikke er FERDIG") {
-                    map { it.id } shouldContainExactlyInAnyOrder listOf(1L, 2L, 3L)
-                    forAll { it.status shouldNotBe FERDIG }
-                }
-                withClue("dataSendt og dataMottatt skal være null i denne 'lette' responsen") {
-                    forAll {
-                        it.dataSendt.shouldBeNull()
-                        it.dataMottatt.shouldBeNull()
-                    }
+        Given("bestillingsbatcher som ikke har status FEILET") {
+            When("rerun kjøres for batcher med andre statuser") {
+                withData(NY, FERDIG, RETRY) { status ->
+                    val id = status.ordinal.toLong()
+                    databaseHas(aBestillingsbatch(id = id, ref = "x", status = status))
+                    shouldThrow<IllegalArgumentException> { bestillingsbatchService.rerun(id) }
+                    tx { BestillingsbatchRepository.findById(it, id)!!.status } shouldBe status
                 }
             }
         }
-        test("rerun - setter FEILET-batch til RETRY og returnerer 1") {
-            databaseHas(
-                aBestillingsbatch(id = 1L, ref = "feilet", status = FEILET),
-            )
 
-            val updated = bestillingsbatchService.rerun(1L)
+        Given("en bestillingsbatchrepository-rerun mot en batch som ikke er FEILET") {
+            When("rerun kjøres direkte i repository") {
+                databaseHas(aBestillingsbatch(id = 101L, ref = "ny", status = NY))
 
-            val batch = tx { BestillingsbatchRepository.findById(it, 1L) }
+                val affected = tx { BestillingsbatchRepository.rerun(it, 101L) }
 
-            assertSoftly {
-                updated shouldBe 1
-                batch.shouldNotBeNull()
-                batch.status shouldBe RETRY
-            }
-        }
-
-        test("rerun - kaster IllegalArgumentException når batch ikke finnes") {
-            // tom database
-
-            val ex =
-                shouldThrow<IllegalArgumentException> {
-                    bestillingsbatchService.rerun(99999L)
+                Then("ingen rader oppdateres og status forblir NY") {
+                    affected shouldBe 0
+                    tx { BestillingsbatchRepository.findById(it, 101L)!!.status } shouldBe NY
                 }
-            ex.message shouldBe "Kunne ikke finne bestillingsbatch med id 99999 for rerun"
-        }
-
-        test("getAllBestillings - returnerer alle bestillinger uavhengig av batch-tilknytning") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, "01010100001"),
-                aPerson(2L),
-                afoedselsnummer(2L, "02020200002"),
-                aPerson(3L),
-                afoedselsnummer(3L, "03030300003"),
-                aBestillingsbatch(id = 10L, ref = "ref-a", status = NY),
-                aBestilling(personId = 1L, fnr = "01010100001", inntektsaar = 2025, batchId = 10L),
-                aBestilling(personId = 2L, fnr = "02020200002", inntektsaar = 2026, batchId = 10L),
-                aBestilling(personId = 3L, fnr = "03030300003", inntektsaar = 2026, batchId = null),
-            )
-
-            val bestillinger = bestillingsbatchService.getAllBestillings()
-
-            bestillinger.shouldContainAllIgnoringFields(
-                listOf(
-                    Bestilling(
-                        personId = PersonId(1L),
-                        fnr = Personidentifikator("01010100001"),
-                        inntektsaar = 2025,
-                        bestillingsbatchId = BestillingsbatchId(10L),
-                    ),
-                    Bestilling(
-                        personId = PersonId(2L),
-                        fnr = Personidentifikator("02020200002"),
-                        inntektsaar = 2026,
-                        bestillingsbatchId = BestillingsbatchId(10L),
-                    ),
-                    Bestilling(
-                        personId = PersonId(3L),
-                        fnr = Personidentifikator("03030300003"),
-                        inntektsaar = 2026,
-                        bestillingsbatchId = null,
-                    ),
-                ),
-                Bestilling::id,
-                Bestilling::oppdatert,
-            )
-        }
-
-        context("rerun feiler for alle ikke-FEILET statuser") {
-            withData(NY, FERDIG, RETRY) { status ->
-                val id = status.ordinal.toLong()
-                databaseHas(aBestillingsbatch(id = id, ref = "x", status = status))
-                shouldThrow<IllegalArgumentException> { bestillingsbatchService.rerun(id) }
-                tx { BestillingsbatchRepository.findById(it, id)!!.status } shouldBe status
             }
         }
 
-        test("BestillingsbatchRepository.rerun - oppdaterer 0 rader når batch har annen status enn FEILET") {
-            databaseHas(aBestillingsbatch(id = 101L, ref = "ny", status = NY))
+        Given("bestillingsbatcher med status FERDIG, NY og RETRY") {
+            When("første ikke-ferdige batch hentes") {
+                databaseHas(
+                    aBestillingsbatch(id = 1L, ref = "ref1", status = FERDIG),
+                    aBestillingsbatch(id = 2L, ref = "ref2", status = NY),
+                    aBestillingsbatch(id = 3L, ref = "ref3", status = RETRY),
+                )
 
-            val affected = tx { BestillingsbatchRepository.rerun(it, 101L) }
+                val result = tx { BestillingsbatchRepository.getFirstNotFerdigBestillingsbatch(it) }
 
-            affected shouldBe 0
-            tx { BestillingsbatchRepository.findById(it, 101L)!!.status } shouldBe NY
+                Then("første batch med status NY eller RETRY returneres") {
+                    result.shouldNotBeNull()
+                    result.id shouldBe BestillingsbatchId(2L)
+                    result.bestillingsreferanse shouldBe "ref2"
+                    result.status shouldBe NY
+                }
+            }
         }
 
-        test("BestillingsbatchRepository.getFirstNotFerdigBestillingsbatch - returnerer første batch med status NY eller RETRY") {
-            databaseHas(
-                aBestillingsbatch(id = 1L, ref = "ref1", status = FERDIG),
-                aBestillingsbatch(id = 2L, ref = "ref2", status = NY),
-                aBestillingsbatch(id = 3L, ref = "ref3", status = RETRY),
-            )
+        Given("bestillingsbatcher uten status NY eller RETRY") {
+            When("første ikke-ferdige batch hentes") {
+                databaseHas(
+                    aBestillingsbatch(id = 1L, ref = "ref1", status = FERDIG),
+                    aBestillingsbatch(id = 2L, ref = "ref2", status = FEILET),
+                )
 
-            val result = tx { BestillingsbatchRepository.getFirstNotFerdigBestillingsbatch(it) }
+                val result = tx { BestillingsbatchRepository.getFirstNotFerdigBestillingsbatch(it) }
 
-            result.shouldNotBeNull()
-            result.id shouldBe BestillingsbatchId(2L)
-            result.bestillingsreferanse shouldBe "ref2"
-            result.status shouldBe NY
-        }
-
-        test("BestillingsbatchRepository.getFirstNotFerdigBestillingsbatch - returnerer null når ingen batcher har status NY eller RETRY") {
-            databaseHas(
-                aBestillingsbatch(id = 1L, ref = "ref1", status = FERDIG),
-                aBestillingsbatch(id = 2L, ref = "ref2", status = FEILET),
-            )
-
-            val result = tx { BestillingsbatchRepository.getFirstNotFerdigBestillingsbatch(it) }
-
-            result.shouldBeNull()
+                Then("returneres null") {
+                    result.shouldBeNull()
+                }
+            }
         }
     })
 

--- a/src/test/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataServiceTest.kt
@@ -3,7 +3,7 @@ package no.nav.sokos.skattekort.skattekortdata
 import java.math.BigDecimal
 
 import io.kotest.assertions.assertSoftly
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
@@ -35,7 +35,7 @@ import no.nav.sokos.skattekort.utils.TestUtils.tx
 import no.nav.sokos.skattekort.utsending.UtsendingRepository
 
 class SkattekortDataServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(DbListener)
 
         val skattekortDataService: SkattekortDataService by lazy {
@@ -44,561 +44,640 @@ class SkattekortDataServiceTest :
 
         val fnr = "01010112345"
 
-        test("processSkattekortData should do nothing when no unprocessed skattekort data exists") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
+        Given("en person med abonnement men uten ubehandlede skattekortdata") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
 
-            skattekortDataService.processSkattekortData()
+            When("skattekortdata behandles") {
+                Then("skal det ikke persisteres noen skattekort") {
+                    seedData()
 
-            val skattekort: List<Skattekort> =
-                tx {
-                    SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true)
-                }
-            skattekort.shouldBeEmpty()
-        }
+                    skattekortDataService.processSkattekortData()
 
-        test("processSkattekortData should persist skattekort and create utsending for abonnement") {
-
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
-
-            val skattekortJson = readFile("/skatteetaten/skattekortData/skattekortopplysningerOK.json")
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
-
-            skattekortDataService.processSkattekortData()
-
-            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
-            val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
-            val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
-
-            assertSoftly {
-                skattekortDataList shouldBe emptyList()
-                skattekortList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        generertFra shouldBe null
-                        identifikator shouldBe "54407"
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SKATTEETATEN.value
-                        resultatForSkattekort shouldBe SkattekortopplysningerOK
-                        forskuddstrekkList.shouldContainExactly(
-                            Tabellkort(Trekkode.LOENN_FRA_HOVEDARBEIDSGIVER, "8140", BigDecimal("43.00"), BigDecimal("10.5")),
-                            Prosentkort(Trekkode.LOENN_FRA_BIARBEIDSGIVER, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.UFOEREYTELSER_FRA_ANDRE, BigDecimal("43.00")),
-                        )
-
-                        tilleggsopplysningList shouldBe emptyList()
-                    }
-                }
-
-                utsendingList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        this.fnr.value shouldBe fnr
-                        inntektsaar shouldBe 2025
-                        forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
-                        failMessage shouldBe null
-                        failCount shouldBe 0
-                    }
+                    val skattekort: List<Skattekort> =
+                        tx {
+                            SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true)
+                        }
+                    skattekort.shouldBeEmpty()
                 }
             }
         }
 
-        test("processSkattekortData should handle tomt frikort and keep frikortbeløp as null") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
-
-            val skattekortJson = readFile("/skatteetaten/skattekortData/skattekortopplysningerOK_med_tomt_frikort.json")
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
-
-            skattekortDataService.processSkattekortData()
-
-            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
-            val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
-            val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
-
-            assertSoftly {
-                skattekortDataList shouldBe emptyList()
-                skattekortList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        generertFra shouldBe null
-                        identifikator shouldBe "54407"
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SKATTEETATEN.value
-                        resultatForSkattekort shouldBe SkattekortopplysningerOK
-                        forskuddstrekkList.shouldContainExactly(
-                            Frikort(Trekkode.UFOERETRYGD_FRA_NAV, null),
-                            Frikort(Trekkode.UFOEREYTELSER_FRA_ANDRE, null),
-                            Frikort(Trekkode.PENSJON_FRA_NAV, null),
-                            Frikort(Trekkode.PENSJON, null),
-                        )
-
-                        tilleggsopplysningList.shouldContainExactly(
-                            Tilleggsopplysning.KILDESKATT_PAA_PENSJON,
-                        )
-                    }
-                }
-
-                utsendingList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        this.fnr.value shouldBe fnr
-                        inntektsaar shouldBe 2025
-                        forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
-                        failMessage shouldBe null
-                        failCount shouldBe 0
-                    }
-                }
+        Given("en person med abonnement og skattekortopplysningerOK-data") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
             }
-        }
 
-        test("processSkattekortData should persist tilleggsopplysninger and synthesize skattekort when oppholdPaaSvalbard is present") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
+            When("skattekortdata behandles") {
+                Then("skal skattekort persisteres og utsending opprettes for abonnementet") {
+                    seedData()
 
-            val skattekortJson = readFile("/skatteetaten/skattekortData/skattekortopplysningerOK_med_oppholdPaaSvalbard.json")
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+                    val skattekortJson = readFile("/skatteetaten/skattekortData/skattekortopplysningerOK.json")
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
 
-            skattekortDataService.processSkattekortData()
+                    skattekortDataService.processSkattekortData()
 
-            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
-            val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
-            val auditList = tx { AuditRepository.getAuditByPersonId(it, PersonId(1)) }
-            val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
+                    val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
+                    val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
+                    val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
 
-            assertSoftly {
-                skattekortDataList shouldBe emptyList()
-                skattekortList shouldNotBeNull {
-                    size shouldBe 2
+                    assertSoftly {
+                        skattekortDataList shouldBe emptyList()
+                        skattekortList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                generertFra shouldBe null
+                                identifikator shouldBe "54407"
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SKATTEETATEN.value
+                                resultatForSkattekort shouldBe SkattekortopplysningerOK
+                                forskuddstrekkList.shouldContainExactly(
+                                    Tabellkort(Trekkode.LOENN_FRA_HOVEDARBEIDSGIVER, "8140", BigDecimal("43.00"), BigDecimal("10.5")),
+                                    Prosentkort(Trekkode.LOENN_FRA_BIARBEIDSGIVER, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.UFOEREYTELSER_FRA_ANDRE, BigDecimal("43.00")),
+                                )
 
-                    val original = first { it.kilde == SkattekortKilde.SKATTEETATEN.value }
-                    val syntetisert = first { it.kilde == SkattekortKilde.SYNTETISERT.value }
+                                tilleggsopplysningList shouldBe emptyList()
+                            }
+                        }
 
-                    original shouldNotBeNull {
-                        generertFra shouldBe null
-                        identifikator shouldBe "54407"
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SKATTEETATEN.value
-                        resultatForSkattekort shouldBe SkattekortopplysningerOK
-                        forskuddstrekkList.shouldContainExactly(
-                            Tabellkort(Trekkode.LOENN_FRA_HOVEDARBEIDSGIVER, "8140", BigDecimal("43.00"), BigDecimal("10.5")),
-                            Prosentkort(Trekkode.LOENN_FRA_BIARBEIDSGIVER, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.UFOEREYTELSER_FRA_ANDRE, BigDecimal("43.00")),
-                        )
-                        tilleggsopplysningList.shouldContainExactly(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD)
-                    }
-
-                    syntetisert shouldNotBeNull {
-                        generertFra shouldBe original.id
-                        identifikator shouldBe null
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SYNTETISERT.value
-                        resultatForSkattekort shouldBe SkattekortopplysningerOK
-                        forskuddstrekkList.shouldContainExactly(
-                            Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("15.70"), null),
-                            Prosentkort(Trekkode.PENSJON_FRA_NAV, BigDecimal("13.10"), null),
-                            Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("15.70"), null),
-                        )
-                    }
-                }
-
-                utsendingList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        this.fnr.value shouldBe fnr
-                        inntektsaar shouldBe 2025
-                        forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
-                        failMessage shouldBe null
-                        failCount shouldBe 0
-                    }
-                }
-
-                auditList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        personId shouldBe PersonId(1L)
-                        brukerId shouldBe "system"
-                        tag shouldBe AuditTag.SYNTETISERT_SKATTEKORT
-                        informasjon shouldBe "Prosentkort med default skattesatser for Svalbard syntetisert pga mottatt tilleggsinformasjon oppholdPaaSvalbard"
-                    }
-                }
-            }
-        }
-
-        test("processSkattekortData should persist IkkeTrekkplikt and generate synthetic frikort") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
-
-            val skattekortJson =
-                """
-                {
-                  "arbeidstakeridentifikator": "$fnr",
-                  "resultatForSkattekort": "ikkeTrekkplikt",
-                  "inntektsaar": 2025
-                }
-                """.trimIndent()
-
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
-
-            skattekortDataService.processSkattekortData()
-
-            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
-            val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
-            val auditList = tx { AuditRepository.getAuditByPersonId(it, PersonId(1)) }
-            val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
-
-            assertSoftly {
-                skattekortDataList shouldBe emptyList()
-                skattekortList shouldNotBeNull {
-                    size shouldBe 2
-
-                    val original = first { it.kilde == SkattekortKilde.SKATTEETATEN.value }
-                    val syntetisert = first { it.kilde == SkattekortKilde.SYNTETISERT.value }
-
-                    original shouldNotBeNull {
-                        generertFra shouldBe null
-                        identifikator shouldBe null
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SKATTEETATEN.value
-                        resultatForSkattekort shouldBe ResultatForSkattekort.IkkeTrekkplikt
-                        forskuddstrekkList shouldBe emptyList()
-                        tilleggsopplysningList shouldBe emptyList()
-                    }
-
-                    syntetisert shouldNotBeNull {
-                        generertFra shouldBe original.id
-                        identifikator shouldBe null
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SYNTETISERT.value
-                        resultatForSkattekort shouldBe ResultatForSkattekort.IkkeTrekkplikt
-                        forskuddstrekkList.shouldContainExactly(
-                            Frikort(Trekkode.LOENN_FRA_NAV, null),
-                            Frikort(Trekkode.PENSJON_FRA_NAV, null),
-                            Frikort(Trekkode.UFOERETRYGD_FRA_NAV, null),
-                        )
-                    }
-                }
-
-                utsendingList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        this.fnr.value shouldBe fnr
-                        inntektsaar shouldBe 2025
-                        forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
-                        failMessage shouldBe null
-                        failCount shouldBe 0
-                    }
-                }
-
-                auditList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        personId shouldBe PersonId(1L)
-                        brukerId shouldBe "system"
-                        tag shouldBe AuditTag.SYNTETISERT_SKATTEKORT
-                        informasjon shouldBe "Frikort uten beløpsgrense syntetisert fordi brukeren ikke er trekkpliktig"
-                    }
-                }
-            }
-        }
-
-        test("processSkattekortData should not create duplicate utsendinger for same abonnement when run twice for same data") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
-
-            val skattekortJson =
-                """
-                {
-                  "arbeidstakeridentifikator": "$fnr",
-                  "resultatForSkattekort": "skattekortopplysningerOK",
-                  "inntektsaar": 2025,
-                  "skattekort": {
-                    "utstedtDato": "2025-11-01",
-                    "skattekortidentifikator": 10001,
-                    "forskuddstrekk": []
-                  }
-                }
-                """.trimIndent()
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
-
-            skattekortDataService.processSkattekortData()
-            skattekortDataService.processSkattekortData()
-
-            val utsendinger = tx(UtsendingRepository::getAllUtsendinger)
-            utsendinger shouldHaveSize 1
-        }
-
-        test("processSkattekortData should not create utsendinger for person not exists in database") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
-
-            val skattekortJson =
-                """
-                {
-                  "arbeidstakeridentifikator": "01010112345",
-                  "resultatForSkattekort": "skattekortopplysningerOK",
-                  "inntektsaar": 2025,
-                  "skattekort": {
-                    "utstedtDato": "2025-11-01",
-                    "skattekortidentifikator": 10001,
-                    "forskuddstrekk": []
-                  }
-                }
-                """.trimIndent()
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
-        }
-
-        test("processSkattekortData should persist all tilleggsopplysninger and synthesize skattekort") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
-
-            val skattekortJson = readFile("/skatteetaten/skattekortData/skattekortopplysningerOK_med_alle_tilleggsopplysninger.json")
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
-
-            skattekortDataService.processSkattekortData()
-
-            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
-            val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
-            val auditList = tx { AuditRepository.getAuditByPersonId(it, PersonId(1)) }
-            val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
-
-            assertSoftly {
-                skattekortDataList shouldBe emptyList()
-                skattekortList shouldNotBeNull {
-                    size shouldBe 2
-
-                    val original = first { it.kilde == SkattekortKilde.SKATTEETATEN.value }
-                    val syntetisert = first { it.kilde == SkattekortKilde.SYNTETISERT.value }
-
-                    original shouldNotBeNull {
-                        generertFra shouldBe null
-                        identifikator shouldBe "54407"
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SKATTEETATEN.value
-                        resultatForSkattekort shouldBe SkattekortopplysningerOK
-                        forskuddstrekkList.shouldContainExactly(
-                            Tabellkort(Trekkode.LOENN_FRA_HOVEDARBEIDSGIVER, "8140", BigDecimal("43.00"), BigDecimal("10.5")),
-                            Prosentkort(Trekkode.LOENN_FRA_BIARBEIDSGIVER, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("43.00")),
-                            Prosentkort(Trekkode.UFOEREYTELSER_FRA_ANDRE, BigDecimal("43.00")),
-                        )
-                        tilleggsopplysningList.shouldContainExactly(
-                            Tilleggsopplysning.OPPHOLD_PAA_SVALBARD,
-                            Tilleggsopplysning.KILDESKATT_PAA_PENSJON,
-                            Tilleggsopplysning.OPPHOLD_I_TILTAKSSONE,
-                        )
-                    }
-
-                    syntetisert shouldNotBeNull {
-                        generertFra shouldBe original.id
-                        identifikator shouldBe null
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SYNTETISERT.value
-                        resultatForSkattekort shouldBe SkattekortopplysningerOK
-                        forskuddstrekkList.shouldContainExactly(
-                            Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("15.70"), null),
-                            Prosentkort(Trekkode.PENSJON_FRA_NAV, BigDecimal("13.10"), null),
-                            Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("15.70"), null),
-                        )
-                        tilleggsopplysningList.shouldContainExactly(
-                            Tilleggsopplysning.OPPHOLD_PAA_SVALBARD,
-                            Tilleggsopplysning.KILDESKATT_PAA_PENSJON,
-                            Tilleggsopplysning.OPPHOLD_I_TILTAKSSONE,
-                        )
-                    }
-                }
-
-                utsendingList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        this.fnr.value shouldBe fnr
-                        inntektsaar shouldBe 2025
-                        forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
-                        failMessage shouldBe null
-                        failCount shouldBe 0
-                    }
-                }
-
-                auditList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        personId shouldBe PersonId(1L)
-                        brukerId shouldBe "system"
-                        tag shouldBe AuditTag.SYNTETISERT_SKATTEKORT
-                        informasjon shouldBe "Prosentkort med default skattesatser for Svalbard syntetisert pga mottatt tilleggsinformasjon oppholdPaaSvalbard"
-                    }
-                }
-            }
-        }
-
-        test("processSkattekortData should persist ugyldigFoedselsEllerDnummer skattekort") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
-
-            val skattekortJson =
-                """                
-                {
-                  "arbeidstakeridentifikator": "$fnr",
-                  "resultatForSkattekort": "ugyldigFoedselsEllerDnummer",
-                  "inntektsaar": 2025
-                }                
-                """.trimIndent()
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
-
-            skattekortDataService.processSkattekortData()
-
-            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
-            val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
-            val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
-
-            assertSoftly {
-                skattekortDataList shouldBe emptyList()
-                skattekortList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        identifikator shouldBe null
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SKATTEETATEN.value
-                        resultatForSkattekort shouldBe ResultatForSkattekort.UgyldigFoedselsEllerDnummer
-                        forskuddstrekkList shouldBe emptyList()
-                        tilleggsopplysningList shouldBe emptyList()
-                    }
-                }
-
-                utsendingList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        this.fnr.value shouldBe fnr
-                        inntektsaar shouldBe 2025
-                        forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
-                        failMessage shouldBe null
-                        failCount shouldBe 0
-                    }
-                }
-            }
-        }
-
-        test("processSkattekortData should persist kkeSkattekort with tilleggsopplysninger oppholdPaaSvalbard") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(1L, fnr),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-            )
-
-            val skattekortJson =
-                """                
-                {
-                  "arbeidstakeridentifikator": "$fnr",
-                  "resultatForSkattekort": "ikkeSkattekort",
-                  "tilleggsopplysning": [
-                        "oppholdPaaSvalbard"
-                    ],
-                  "inntektsaar": 2025
-                }                
-                """.trimIndent()
-            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
-
-            skattekortDataService.processSkattekortData()
-
-            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
-            val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
-            val auditList = tx { AuditRepository.getAuditByPersonId(it, PersonId(1)) }
-            val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
-
-            assertSoftly {
-                skattekortDataList shouldBe emptyList()
-                skattekortList shouldNotBeNull {
-                    size shouldBe 2
-
-                    val original = first { it.kilde == SkattekortKilde.SKATTEETATEN.value }
-                    val syntetisert = first { it.kilde == SkattekortKilde.SYNTETISERT.value }
-
-                    original shouldNotBeNull {
-                        generertFra shouldBe null
-                        identifikator shouldBe null
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SKATTEETATEN.value
-                        resultatForSkattekort shouldBe IkkeSkattekort
-                        forskuddstrekkList shouldBe extensions
-                        tilleggsopplysningList.shouldContainExactly(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD)
-                    }
-
-                    syntetisert shouldNotBeNull {
-                        generertFra shouldBe original.id
-                        identifikator shouldBe null
-                        personId shouldBe PersonId(1L)
-                        inntektsaar shouldBe 2025
-                        kilde shouldBe SkattekortKilde.SYNTETISERT.value
-                        resultatForSkattekort shouldBe IkkeSkattekort
-                        forskuddstrekkList.shouldContainExactly(
-                            Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("15.70"), null),
-                            Prosentkort(Trekkode.PENSJON_FRA_NAV, BigDecimal("13.10"), null),
-                            Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("15.70"), null),
-                        )
-                        tilleggsopplysningList.shouldContainExactly(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD)
-                    }
-
-                    utsendingList shouldNotBeNull {
-                        size shouldBe 1
-                        first() shouldNotBeNull {
-                            this.fnr.value shouldBe fnr
-                            inntektsaar shouldBe 2025
-                            forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
-                            failMessage shouldBe null
-                            failCount shouldBe 0
+                        utsendingList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                this.fnr.value shouldBe fnr
+                                inntektsaar shouldBe 2025
+                                forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                                failMessage shouldBe null
+                                failCount shouldBe 0
+                            }
                         }
                     }
+                }
+            }
+        }
 
-                    auditList shouldNotBeNull {
-                        size shouldBe 1
-                        first() shouldNotBeNull {
-                            personId shouldBe PersonId(1L)
-                            brukerId shouldBe "system"
-                            tag shouldBe AuditTag.SYNTETISERT_SKATTEKORT
-                            informasjon shouldBe "Prosentkort med default skattesatser for Svalbard syntetisert pga mottatt tilleggsinformasjon oppholdPaaSvalbard"
+        Given("en person med abonnement og skattekortdata med tomt frikort") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
+
+            When("skattekortdata behandles") {
+                Then("skal tomt frikort beholdes med null som frikortbeløp") {
+                    seedData()
+
+                    val skattekortJson = readFile("/skatteetaten/skattekortData/skattekortopplysningerOK_med_tomt_frikort.json")
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+
+                    skattekortDataService.processSkattekortData()
+
+                    val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
+                    val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
+                    val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
+
+                    assertSoftly {
+                        skattekortDataList shouldBe emptyList()
+                        skattekortList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                generertFra shouldBe null
+                                identifikator shouldBe "54407"
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SKATTEETATEN.value
+                                resultatForSkattekort shouldBe SkattekortopplysningerOK
+                                forskuddstrekkList.shouldContainExactly(
+                                    Frikort(Trekkode.UFOERETRYGD_FRA_NAV, null),
+                                    Frikort(Trekkode.UFOEREYTELSER_FRA_ANDRE, null),
+                                    Frikort(Trekkode.PENSJON_FRA_NAV, null),
+                                    Frikort(Trekkode.PENSJON, null),
+                                )
+
+                                tilleggsopplysningList.shouldContainExactly(
+                                    Tilleggsopplysning.KILDESKATT_PAA_PENSJON,
+                                )
+                            }
+                        }
+
+                        utsendingList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                this.fnr.value shouldBe fnr
+                                inntektsaar shouldBe 2025
+                                forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                                failMessage shouldBe null
+                                failCount shouldBe 0
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("en person med abonnement og skattekortdata med opphold på Svalbard") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
+
+            When("skattekortdata behandles") {
+                Then("skal tilleggsopplysninger persisteres og syntetisert skattekort opprettes") {
+                    seedData()
+
+                    val skattekortJson = readFile("/skatteetaten/skattekortData/skattekortopplysningerOK_med_oppholdPaaSvalbard.json")
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+
+                    skattekortDataService.processSkattekortData()
+
+                    val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
+                    val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
+                    val auditList = tx { AuditRepository.getAuditByPersonId(it, PersonId(1)) }
+                    val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
+
+                    assertSoftly {
+                        skattekortDataList shouldBe emptyList()
+                        skattekortList shouldNotBeNull {
+                            size shouldBe 2
+
+                            val original = first { it.kilde == SkattekortKilde.SKATTEETATEN.value }
+                            val syntetisert = first { it.kilde == SkattekortKilde.SYNTETISERT.value }
+
+                            original shouldNotBeNull {
+                                generertFra shouldBe null
+                                identifikator shouldBe "54407"
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SKATTEETATEN.value
+                                resultatForSkattekort shouldBe SkattekortopplysningerOK
+                                forskuddstrekkList.shouldContainExactly(
+                                    Tabellkort(Trekkode.LOENN_FRA_HOVEDARBEIDSGIVER, "8140", BigDecimal("43.00"), BigDecimal("10.5")),
+                                    Prosentkort(Trekkode.LOENN_FRA_BIARBEIDSGIVER, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.UFOEREYTELSER_FRA_ANDRE, BigDecimal("43.00")),
+                                )
+                                tilleggsopplysningList.shouldContainExactly(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD)
+                            }
+
+                            syntetisert shouldNotBeNull {
+                                generertFra shouldBe original.id
+                                identifikator shouldBe null
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SYNTETISERT.value
+                                resultatForSkattekort shouldBe SkattekortopplysningerOK
+                                forskuddstrekkList.shouldContainExactly(
+                                    Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("15.70"), null),
+                                    Prosentkort(Trekkode.PENSJON_FRA_NAV, BigDecimal("13.10"), null),
+                                    Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("15.70"), null),
+                                )
+                            }
+                        }
+
+                        utsendingList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                this.fnr.value shouldBe fnr
+                                inntektsaar shouldBe 2025
+                                forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                                failMessage shouldBe null
+                                failCount shouldBe 0
+                            }
+                        }
+
+                        auditList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                personId shouldBe PersonId(1L)
+                                brukerId shouldBe "system"
+                                tag shouldBe AuditTag.SYNTETISERT_SKATTEKORT
+                                informasjon shouldBe "Prosentkort med default skattesatser for Svalbard syntetisert pga mottatt tilleggsinformasjon oppholdPaaSvalbard"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("en person med abonnement og ikke trekkpliktige skattekortdata") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
+
+            When("skattekortdata behandles") {
+                Then("skal IkkeTrekkplikt persisteres og syntetisk frikort genereres") {
+                    seedData()
+
+                    val skattekortJson =
+                        """
+                        {
+                          "arbeidstakeridentifikator": "$fnr",
+                          "resultatForSkattekort": "ikkeTrekkplikt",
+                          "inntektsaar": 2025
+                        }
+                        """.trimIndent()
+
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+
+                    skattekortDataService.processSkattekortData()
+
+                    val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
+                    val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
+                    val auditList = tx { AuditRepository.getAuditByPersonId(it, PersonId(1)) }
+                    val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
+
+                    assertSoftly {
+                        skattekortDataList shouldBe emptyList()
+                        skattekortList shouldNotBeNull {
+                            size shouldBe 2
+
+                            val original = first { it.kilde == SkattekortKilde.SKATTEETATEN.value }
+                            val syntetisert = first { it.kilde == SkattekortKilde.SYNTETISERT.value }
+
+                            original shouldNotBeNull {
+                                generertFra shouldBe null
+                                identifikator shouldBe null
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SKATTEETATEN.value
+                                resultatForSkattekort shouldBe ResultatForSkattekort.IkkeTrekkplikt
+                                forskuddstrekkList shouldBe emptyList()
+                                tilleggsopplysningList shouldBe emptyList()
+                            }
+
+                            syntetisert shouldNotBeNull {
+                                generertFra shouldBe original.id
+                                identifikator shouldBe null
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SYNTETISERT.value
+                                resultatForSkattekort shouldBe ResultatForSkattekort.IkkeTrekkplikt
+                                forskuddstrekkList.shouldContainExactly(
+                                    Frikort(Trekkode.LOENN_FRA_NAV, null),
+                                    Frikort(Trekkode.PENSJON_FRA_NAV, null),
+                                    Frikort(Trekkode.UFOERETRYGD_FRA_NAV, null),
+                                )
+                            }
+                        }
+
+                        utsendingList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                this.fnr.value shouldBe fnr
+                                inntektsaar shouldBe 2025
+                                forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                                failMessage shouldBe null
+                                failCount shouldBe 0
+                            }
+                        }
+
+                        auditList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                personId shouldBe PersonId(1L)
+                                brukerId shouldBe "system"
+                                tag shouldBe AuditTag.SYNTETISERT_SKATTEKORT
+                                informasjon shouldBe "Frikort uten beløpsgrense syntetisert fordi brukeren ikke er trekkpliktig"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("en person med abonnement og samme skattekortdata behandles to ganger") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
+
+            When("prosesseringen kjøres to ganger") {
+                Then("skal det ikke opprettes dupliserte utsendinger") {
+                    seedData()
+
+                    val skattekortJson =
+                        """
+                        {
+                          "arbeidstakeridentifikator": "$fnr",
+                          "resultatForSkattekort": "skattekortopplysningerOK",
+                          "inntektsaar": 2025,
+                          "skattekort": {
+                            "utstedtDato": "2025-11-01",
+                            "skattekortidentifikator": 10001,
+                            "forskuddstrekk": []
+                          }
+                        }
+                        """.trimIndent()
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+
+                    skattekortDataService.processSkattekortData()
+                    skattekortDataService.processSkattekortData()
+
+                    val utsendinger = tx(UtsendingRepository::getAllUtsendinger)
+                    utsendinger shouldHaveSize 1
+                }
+            }
+        }
+
+        Given("en skattekortdatapost for en person som ikke finnes i databasen") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
+
+            When("skattekortdata lagres") {
+                Then("beholdes den eksisterende testen uten videre prosessering") {
+                    seedData()
+
+                    val skattekortJson =
+                        """
+                        {
+                          "arbeidstakeridentifikator": "01010112345",
+                          "resultatForSkattekort": "skattekortopplysningerOK",
+                          "inntektsaar": 2025,
+                          "skattekort": {
+                            "utstedtDato": "2025-11-01",
+                            "skattekortidentifikator": 10001,
+                            "forskuddstrekk": []
+                          }
+                        }
+                        """.trimIndent()
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+                }
+            }
+        }
+
+        Given("en person med abonnement og alle tilleggsopplysninger i skattekortdata") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
+
+            When("skattekortdata behandles") {
+                Then("skal alle tilleggsopplysninger persisteres og syntetisert skattekort opprettes") {
+                    seedData()
+
+                    val skattekortJson = readFile("/skatteetaten/skattekortData/skattekortopplysningerOK_med_alle_tilleggsopplysninger.json")
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+
+                    skattekortDataService.processSkattekortData()
+
+                    val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
+                    val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
+                    val auditList = tx { AuditRepository.getAuditByPersonId(it, PersonId(1)) }
+                    val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
+
+                    assertSoftly {
+                        skattekortDataList shouldBe emptyList()
+                        skattekortList shouldNotBeNull {
+                            size shouldBe 2
+
+                            val original = first { it.kilde == SkattekortKilde.SKATTEETATEN.value }
+                            val syntetisert = first { it.kilde == SkattekortKilde.SYNTETISERT.value }
+
+                            original shouldNotBeNull {
+                                generertFra shouldBe null
+                                identifikator shouldBe "54407"
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SKATTEETATEN.value
+                                resultatForSkattekort shouldBe SkattekortopplysningerOK
+                                forskuddstrekkList.shouldContainExactly(
+                                    Tabellkort(Trekkode.LOENN_FRA_HOVEDARBEIDSGIVER, "8140", BigDecimal("43.00"), BigDecimal("10.5")),
+                                    Prosentkort(Trekkode.LOENN_FRA_BIARBEIDSGIVER, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("43.00")),
+                                    Prosentkort(Trekkode.UFOEREYTELSER_FRA_ANDRE, BigDecimal("43.00")),
+                                )
+                                tilleggsopplysningList.shouldContainExactly(
+                                    Tilleggsopplysning.OPPHOLD_PAA_SVALBARD,
+                                    Tilleggsopplysning.KILDESKATT_PAA_PENSJON,
+                                    Tilleggsopplysning.OPPHOLD_I_TILTAKSSONE,
+                                )
+                            }
+
+                            syntetisert shouldNotBeNull {
+                                generertFra shouldBe original.id
+                                identifikator shouldBe null
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SYNTETISERT.value
+                                resultatForSkattekort shouldBe SkattekortopplysningerOK
+                                forskuddstrekkList.shouldContainExactly(
+                                    Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("15.70"), null),
+                                    Prosentkort(Trekkode.PENSJON_FRA_NAV, BigDecimal("13.10"), null),
+                                    Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("15.70"), null),
+                                )
+                                tilleggsopplysningList.shouldContainExactly(
+                                    Tilleggsopplysning.OPPHOLD_PAA_SVALBARD,
+                                    Tilleggsopplysning.KILDESKATT_PAA_PENSJON,
+                                    Tilleggsopplysning.OPPHOLD_I_TILTAKSSONE,
+                                )
+                            }
+                        }
+
+                        utsendingList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                this.fnr.value shouldBe fnr
+                                inntektsaar shouldBe 2025
+                                forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                                failMessage shouldBe null
+                                failCount shouldBe 0
+                            }
+                        }
+
+                        auditList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                personId shouldBe PersonId(1L)
+                                brukerId shouldBe "system"
+                                tag shouldBe AuditTag.SYNTETISERT_SKATTEKORT
+                                informasjon shouldBe "Prosentkort med default skattesatser for Svalbard syntetisert pga mottatt tilleggsinformasjon oppholdPaaSvalbard"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("en person med abonnement og ugyldigFoedselsEllerDnummer i skattekortdata") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
+
+            When("skattekortdata behandles") {
+                Then("skal skattekortet persisteres med riktig resultat") {
+                    seedData()
+
+                    val skattekortJson =
+                        """                
+                        {
+                          "arbeidstakeridentifikator": "$fnr",
+                          "resultatForSkattekort": "ugyldigFoedselsEllerDnummer",
+                          "inntektsaar": 2025
+                        }                
+                        """.trimIndent()
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+
+                    skattekortDataService.processSkattekortData()
+
+                    val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
+                    val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
+                    val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
+
+                    assertSoftly {
+                        skattekortDataList shouldBe emptyList()
+                        skattekortList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                identifikator shouldBe null
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SKATTEETATEN.value
+                                resultatForSkattekort shouldBe ResultatForSkattekort.UgyldigFoedselsEllerDnummer
+                                forskuddstrekkList shouldBe emptyList()
+                                tilleggsopplysningList shouldBe emptyList()
+                            }
+                        }
+
+                        utsendingList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                this.fnr.value shouldBe fnr
+                                inntektsaar shouldBe 2025
+                                forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                                failMessage shouldBe null
+                                failCount shouldBe 0
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("en person med abonnement og ikkeSkattekort med opphold på Svalbard") {
+            fun seedData() {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(1L, fnr),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                )
+            }
+
+            When("skattekortdata behandles") {
+                Then("skal ikkeSkattekort persisteres sammen med syntetisert skattekort") {
+                    seedData()
+
+                    val skattekortJson =
+                        """                
+                        {
+                          "arbeidstakeridentifikator": "$fnr",
+                          "resultatForSkattekort": "ikkeSkattekort",
+                          "tilleggsopplysning": [
+                                "oppholdPaaSvalbard"
+                            ],
+                          "inntektsaar": 2025
+                        }                
+                        """.trimIndent()
+                    tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr) }
+
+                    skattekortDataService.processSkattekortData()
+
+                    val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = true) }
+                    val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
+                    val auditList = tx { AuditRepository.getAuditByPersonId(it, PersonId(1)) }
+                    val skattekortDataList = tx(SkattekortDataRepository::getUnprocessedSkattekortData)
+
+                    assertSoftly {
+                        skattekortDataList shouldBe emptyList()
+                        skattekortList shouldNotBeNull {
+                            size shouldBe 2
+
+                            val original = first { it.kilde == SkattekortKilde.SKATTEETATEN.value }
+                            val syntetisert = first { it.kilde == SkattekortKilde.SYNTETISERT.value }
+
+                            original shouldNotBeNull {
+                                generertFra shouldBe null
+                                identifikator shouldBe null
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SKATTEETATEN.value
+                                resultatForSkattekort shouldBe IkkeSkattekort
+                                forskuddstrekkList shouldBe extensions
+                                tilleggsopplysningList.shouldContainExactly(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD)
+                            }
+
+                            syntetisert shouldNotBeNull {
+                                generertFra shouldBe original.id
+                                identifikator shouldBe null
+                                personId shouldBe PersonId(1L)
+                                inntektsaar shouldBe 2025
+                                kilde shouldBe SkattekortKilde.SYNTETISERT.value
+                                resultatForSkattekort shouldBe IkkeSkattekort
+                                forskuddstrekkList.shouldContainExactly(
+                                    Prosentkort(Trekkode.LOENN_FRA_NAV, BigDecimal("15.70"), null),
+                                    Prosentkort(Trekkode.PENSJON_FRA_NAV, BigDecimal("13.10"), null),
+                                    Prosentkort(Trekkode.UFOERETRYGD_FRA_NAV, BigDecimal("15.70"), null),
+                                )
+                                tilleggsopplysningList.shouldContainExactly(Tilleggsopplysning.OPPHOLD_PAA_SVALBARD)
+                            }
+
+                            utsendingList shouldNotBeNull {
+                                size shouldBe 1
+                                first() shouldNotBeNull {
+                                    this.fnr.value shouldBe fnr
+                                    inntektsaar shouldBe 2025
+                                    forsystem shouldBe Forsystem.OPPDRAGSSYSTEMET
+                                    failMessage shouldBe null
+                                    failCount shouldBe 0
+                                }
+                            }
+
+                            auditList shouldNotBeNull {
+                                size shouldBe 1
+                                first() shouldNotBeNull {
+                                    personId shouldBe PersonId(1L)
+                                    brukerId shouldBe "system"
+                                    tag shouldBe AuditTag.SYNTETISERT_SKATTEKORT
+                                    informasjon shouldBe "Prosentkort med default skattesatser for Svalbard syntetisert pga mottatt tilleggsinformasjon oppholdPaaSvalbard"
+                                }
+                            }
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/sokos/skattekort/skattekorthenting/BestillingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/skattekorthenting/BestillingServiceTest.kt
@@ -13,7 +13,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.time.withConstantNow
 import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forExactly
@@ -64,7 +64,7 @@ import no.nav.sokos.skattekort.utils.TestUtils.tx
 
 @OptIn(ExperimentalTime::class)
 class BestillingServiceTest :
-    FunSpec({
+    BehaviorSpec({
         extensions(DbListener)
 
         val logger = LoggerFactory.getLogger(BestillingService::class.java) as Logger
@@ -88,41 +88,157 @@ class BestillingServiceTest :
             testAppender.list.clear()
         }
 
-        test("henteBestillingsbatcher enkleste scenario") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-                aBestillingsbatch(1, "ref1", NY),
-                aBestilling(1L, "01010100001", 2025, 1L),
-            )
+        Given("en ny bestillingsbatch med én bestilling og vellykket svar fra Skatteetaten") {
+            When("bestillingsbatcher hentes i enkleste scenario") {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                    aBestillingsbatch(1, "ref1", NY),
+                    aBestilling(1L, "01010100001", 2025, 1L),
+                )
 
-            coEvery { skatteetatenClient.hentSkattekort(any()) } returns
-                aHentSkattekortResponse(aSkattekortFor("01010100001", 10001))
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+                coEvery { skatteetatenClient.hentSkattekort(any()) } returns
+                    aHentSkattekortResponse(aSkattekortFor("01010100001", 10001))
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
 
-            val bestilingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
-            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = false) }
-            val bestilliingListAfter = tx(DBTestUtils::getAllBestilling)
-            val skattekortDataList = tx { SkattekortDataRepository.getUnprocessedSkattekortData(it) }
+                val bestilingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+                val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, PersonId(1), 2025, adminRole = false) }
+                val bestilliingListAfter = tx(DBTestUtils::getAllBestilling)
+                val skattekortDataList = tx { SkattekortDataRepository.getUnprocessedSkattekortData(it) }
 
-            assertSoftly {
-                bestilingsbatchList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        status shouldBe FERDIG
+                Then("batchen markeres som ferdig og skattekortdata lagres uten å opprette skattekort") {
+                    assertSoftly {
+                        bestilingsbatchList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                status shouldBe FERDIG
+                            }
+                        }
+                        skattekortDataList.size shouldBe 1
+                        skattekortList shouldBe emptyList()
+                        bestilliingListAfter shouldBe emptyList()
                     }
                 }
-                skattekortDataList.size shouldBe 1
-                skattekortList shouldBe emptyList()
-                bestilliingListAfter shouldBe emptyList()
             }
         }
 
-        test("Logger som feil for ukjente personer fra henteBestillingsbatcher") {
-            withConstantNow(LocalDateTime.parse("2025-12-20T00:00:00")) {
+        Given("en oppdateringsbatch hvor Skatteetaten svarer med et fnr som ikke finnes i databasen") {
+            When("bestillingsbatcher hentes") {
+                withConstantNow(LocalDateTime.parse("2025-12-20T00:00:00")) {
+                    coEvery { skatteetatenClient.hentSkattekort(any()) } returns
+                        aHentSkattekortResponse(aSkattekortFor("0101010000X", 10007))
+
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                        aPerson(2L),
+                        afoedselsnummer(personId = 2L, fnr = "02020200002"),
+                        aPerson(3L),
+                        afoedselsnummer(personId = 3L, fnr = "03030300003"),
+                        aBestillingsbatch(1L, "REF0001", NY, OPPDATERING),
+                    )
+
+                    bestillingService.hentBestillingsbatcher(OPPDATERING)
+
+                    val person = tx { PersonRepository.findPersonByFnr(it, Personidentifikator("0101010000X")) }
+                    val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+
+                    Then("batchen ferdigstilles og det logges en teamlog-feil for ukjent person") {
+                        assertSoftly {
+                            person shouldBe null
+                            bestillingsbatchList shouldNotBeNull {
+                                size shouldBe 1
+                                first() shouldNotBeNull {
+                                    status shouldBe FERDIG
+                                    type shouldBe OPPDATERING
+                                    bestillingsreferanse shouldBe "REF0001"
+                                }
+                            }
+                            testAppender.list.shouldNotBeNull {
+                                forOne {
+                                    it.level shouldBe Level.ERROR
+                                    it.message shouldContain "Fant ikke person for fnr"
+                                    it.markerList.shouldContain(TEAM_LOGS_MARKER)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("en ny bestillingsbatch hvor Skatteetaten svarer at det ikke er endringer") {
+            When("bestillingsbatcher hentes") {
                 coEvery { skatteetatenClient.hentSkattekort(any()) } returns
-                    aHentSkattekortResponse(aSkattekortFor("0101010000X", 10007))
+                    aHentSkattekortResponse(response = ResponseStatus.INGEN_ENDRINGER)
+
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                    aBestillingsbatch(1, "ref1", NY),
+                    aBestilling(1L, "01010100001", 2025, 1L),
+                )
+
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+                val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+
+                Then("batchen markeres som ferdig") {
+                    assertSoftly {
+                        bestillingsbatchList shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                status shouldBe FERDIG
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("en ny bestillingsbatch hvor Skatteetaten returnerer ugyldig inntektsår") {
+            When("bestillingsbatcher hentes") {
+                coEvery { skatteetatenClient.hentSkattekort(any()) } returns
+                    aHentSkattekortResponse(
+                        response = ResponseStatus.UGYLDIG_INNTEKTSAAR,
+                    )
+
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                    aBestillingsbatch(1, "ref1", NY),
+                    aBestilling(1L, "01010100001", 2025, 1L),
+                )
+
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+
+                val updatedBatches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
+
+                Then("batchen markeres som feilet") {
+                    assertSoftly {
+                        updatedBatches shouldNotBeNull {
+                            size shouldBe 1
+                            first() shouldNotBeNull {
+                                status shouldBe FEILET
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Given("flere nye bestillingsbatcher som skal behandles i rekkefølge") {
+            When("bestillingsbatcher hentes to ganger") {
+                coEvery { skatteetatenClient.hentSkattekort(any()) } returns
+                    aHentSkattekortResponse(
+                        aSkattekortFor("01010100001", 10001),
+                    ) andThen
+                    aHentSkattekortResponse(
+                        aSkattekortFor("02020200002", 20002),
+                        aSkattekortFor("03030300003", 30003),
+                    )
 
                 databaseHas(
                     aPerson(1L),
@@ -131,425 +247,356 @@ class BestillingServiceTest :
                     afoedselsnummer(personId = 2L, fnr = "02020200002"),
                     aPerson(3L),
                     afoedselsnummer(personId = 3L, fnr = "03030300003"),
-                    aBestillingsbatch(1L, "REF0001", NY, OPPDATERING),
+                    aPerson(4L),
+                    afoedselsnummer(personId = 4L, fnr = "04040400004"),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                    anAbonnement(2L, personId = 2L, inntektsaar = 2025),
+                    anAbonnement(3L, personId = 3L, inntektsaar = 2025),
+                    anAbonnement(4L, personId = 4L, inntektsaar = 2025),
+                    aBestillingsbatch(1, "ref1", NY),
+                    aBestillingsbatch(2, "ref2", NY),
+                    aBestilling(1L, "01010100001", 2025, 1L),
+                    aBestilling(2L, "02020200002", 2025, 2L),
+                    aBestilling(3L, "02020200003", 2025, 2L),
+                    aBestilling(4L, "04040400004", 2025, null),
                 )
 
-                bestillingService.hentBestillingsbatcher(OPPDATERING)
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
 
-                val person = tx { PersonRepository.findPersonByFnr(it, Personidentifikator("0101010000X")) }
+                val updatedBatches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
+                val skattekortDataList = tx { SkattekortDataRepository.getUnprocessedSkattekortData(it) }
+
+                Then("alle batchene blir markert som ferdig") {
+                    assertSoftly("Etter første kjøring skal alle batchene være Ferdig") {
+                        updatedBatches shouldNotBeNull {
+                            size shouldBe 2
+                            forOne {
+                                it.id!!.id shouldBe 1L
+                                it.status shouldBe FERDIG
+                            }
+                            forOne {
+                                it.id!!.id shouldBe 2L
+                                it.status shouldBe FERDIG
+                            }
+                        }
+                        skattekortDataList.size shouldBe 3
+                    }
+                }
+            }
+        }
+
+        Given("en batch som allerede har status FEILET") {
+            When("bestillingsbatcher hentes") {
+                databaseHas(aBestillingsbatch(id = 1L, ref = "some-ref", status = FEILET))
+
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+
                 val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+                val auditAfter = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
 
-                assertSoftly {
-                    person shouldBe null
-                    bestillingsbatchList shouldNotBeNull {
-                        size shouldBe 1
-                        first() shouldNotBeNull {
-                            status shouldBe FERDIG
-                            type shouldBe OPPDATERING
-                            bestillingsreferanse shouldBe "REF0001"
+                Then("batchen blir stående urørt og det opprettes ingen audit") {
+                    assertSoftly {
+                        bestillingsbatchList shouldNotBeNull {
+                            size shouldBe 1
+                            forExactly(1) { it.status shouldBe FEILET }
                         }
-                    }
-                    testAppender.list.shouldNotBeNull {
-                        forOne {
-                            it.level shouldBe Level.ERROR
-                            it.message shouldContain "Fant ikke person for fnr"
-                            it.markerList.shouldContain(TEAM_LOGS_MARKER)
-                        }
+                        auditAfter shouldBe emptyList()
                     }
                 }
             }
         }
 
-        test("hentBestillingsbatcher, ingen endring-respons") {
-            coEvery { skatteetatenClient.hentSkattekort(any()) } returns
-                aHentSkattekortResponse(response = ResponseStatus.INGEN_ENDRINGER)
-
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-                aBestillingsbatch(1, "ref1", NY),
-                aBestilling(1L, "01010100001", 2025, 1L),
-            )
-
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
-            val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
-
-            assertSoftly {
-                bestillingsbatchList shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        status shouldBe FERDIG
-                    }
-                }
-            }
-        }
-
-        test("hentBestillingsbatcher, ugyldig inntektsaar returneres") {
-            coEvery { skatteetatenClient.hentSkattekort(any()) } returns
-                aHentSkattekortResponse(
-                    response = ResponseStatus.UGYLDIG_INNTEKTSAAR,
+        Given("en ny batch hvor henting av skattekort feiler med 404 fra Skatteetaten") {
+            When("bestillingsbatcher hentes") {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    aPerson(2L),
+                    afoedselsnummer(personId = 2L, fnr = "02020200002"),
+                    aPerson(3L),
+                    afoedselsnummer(personId = 3L, fnr = "03030300003"),
+                    aBestillingsbatch(id = 1L, ref = "ref1", status = NY),
+                    aBestilling(personId = 1L, fnr = "01010100001", inntektsaar = 2025, batchId = 1L),
+                    aBestilling(personId = 2L, fnr = "02020200002", inntektsaar = 2025, batchId = 1L),
+                    aBestilling(personId = 3L, fnr = "03030300003", inntektsaar = 2025, batchId = 1L),
                 )
 
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-                aBestillingsbatch(1, "ref1", NY),
-                aBestilling(1L, "01010100001", 2025, 1L),
-            )
+                coEvery { skatteetatenClient.hentSkattekort(any()) } throws RuntimeException("Feil ved henting av skattekort: 404")
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
 
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+                val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+                val auditPerson1: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
+                val auditPerson2: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(2L)) }
+                val auditPerson3: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(3L)) }
+                val bestillingListAfter = tx(DBTestUtils::getAllBestilling)
 
-            val updatedBatches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
-
-            assertSoftly {
-                updatedBatches shouldNotBeNull {
-                    size shouldBe 1
-                    first() shouldNotBeNull {
-                        status shouldBe FEILET
-                    }
-                }
-            }
-        }
-
-        test("hentBestillingsbatcher håndterer alle batcher") {
-
-            coEvery { skatteetatenClient.hentSkattekort(any()) } returns
-                aHentSkattekortResponse(
-                    aSkattekortFor("01010100001", 10001),
-                ) andThen
-                aHentSkattekortResponse(
-                    aSkattekortFor("02020200002", 20002),
-                    aSkattekortFor("03030300003", 30003),
-                )
-
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                aPerson(2L),
-                afoedselsnummer(personId = 2L, fnr = "02020200002"),
-                aPerson(3L),
-                afoedselsnummer(personId = 3L, fnr = "03030300003"),
-                aPerson(4L),
-                afoedselsnummer(personId = 4L, fnr = "04040400004"),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-                anAbonnement(2L, personId = 2L, inntektsaar = 2025),
-                anAbonnement(3L, personId = 3L, inntektsaar = 2025),
-                anAbonnement(4L, personId = 4L, inntektsaar = 2025),
-                aBestillingsbatch(1, "ref1", NY),
-                aBestillingsbatch(2, "ref2", NY),
-                aBestilling(1L, "01010100001", 2025, 1L),
-                aBestilling(2L, "02020200002", 2025, 2L),
-                aBestilling(3L, "02020200003", 2025, 2L), // NB: også batch 2
-                aBestilling(4L, "04040400004", 2025, null),
-            )
-
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
-
-            val updatedBatches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
-            val skattekortDataList = tx { SkattekortDataRepository.getUnprocessedSkattekortData(it) }
-
-            assertSoftly("Etter første kjøring skal alle batchene være Ferdig") {
-                updatedBatches shouldNotBeNull {
-                    size shouldBe 2
-                    forOne {
-                        it.id!!.id shouldBe 1L
-                        it.status shouldBe FERDIG
-                    }
-                    forOne {
-                        it.id!!.id shouldBe 2L
-                        it.status shouldBe FERDIG
-                    }
-                }
-                skattekortDataList.size shouldBe 3
-            }
-        }
-
-        test("plukker ikke opp batch med status FEILET, gjør ingenting og trenger ikke mer data") {
-            databaseHas(aBestillingsbatch(id = 1L, ref = "some-ref", status = FEILET))
-
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
-
-            val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
-            val auditAfter = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
-
-            assertSoftly {
-                bestillingsbatchList shouldNotBeNull {
-                    size shouldBe 1
-                    forExactly(1) { it.status shouldBe FEILET }
-                }
-                auditAfter shouldBe emptyList()
-            }
-        }
-
-        test("plukker opp batch med status NY, får 404 fra skatt") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                aPerson(2L),
-                afoedselsnummer(personId = 2L, fnr = "02020200002"),
-                aPerson(3L),
-                afoedselsnummer(personId = 3L, fnr = "03030300003"),
-                aBestillingsbatch(id = 1L, ref = "ref1", status = NY),
-                aBestilling(personId = 1L, fnr = "01010100001", inntektsaar = 2025, batchId = 1L),
-                aBestilling(personId = 2L, fnr = "02020200002", inntektsaar = 2025, batchId = 1L),
-                aBestilling(personId = 3L, fnr = "03030300003", inntektsaar = 2025, batchId = 1L),
-            )
-
-            coEvery { skatteetatenClient.hentSkattekort(any()) } throws RuntimeException("Feil ved henting av skattekort: 404")
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
-
-            val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
-            val auditPerson1: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
-            val auditPerson2: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(2L)) }
-            val auditPerson3: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(3L)) }
-            val bestillingListAfter = tx(DBTestUtils::getAllBestilling)
-
-            assertSoftly {
-                withClue("Should mark batch as RETRY") {
-                    bestillingsbatchList shouldNotBeNull {
-                        first().status shouldBe RETRY
-                    }
-                }
-
-                withClue("Should not delete bestilling or remove batch association") {
-                    bestillingListAfter shouldNotBeNull {
-                        size shouldBe 3
-                        forAll {
-                            it.bestillingsbatchId!!.id shouldBe 1L
+                Then("batchen markeres for retry og bestillingene beholdes") {
+                    assertSoftly {
+                        withClue("Should mark batch as RETRY") {
+                            bestillingsbatchList shouldNotBeNull {
+                                first().status shouldBe RETRY
+                            }
                         }
-                    }
-                }
 
-                withClue("Should create auditlog for all persons in batch") {
-                    (auditPerson1 + auditPerson2 + auditPerson3) shouldNotBeNull {
-                        forAll {
-                            it.tag shouldBe AuditTag.HENTING_AV_SKATTEKORT_FEILET
+                        withClue("Should not delete bestilling or remove batch association") {
+                            bestillingListAfter shouldNotBeNull {
+                                size shouldBe 3
+                                forAll {
+                                    it.bestillingsbatchId!!.id shouldBe 1L
+                                }
+                            }
                         }
+
+                        withClue("Should create auditlog for all persons in batch") {
+                            (auditPerson1 + auditPerson2 + auditPerson3) shouldNotBeNull {
+                                forAll {
+                                    it.tag shouldBe AuditTag.HENTING_AV_SKATTEKORT_FEILET
+                                }
+                            }
+                        }
+
+                        testAppender.list
+                            .map { it.level to it.message }
+                            .shouldContainExactlyInAnyOrder(
+                                listOf(
+                                    Level.INFO to "Henter skattekort for ref1",
+                                    Level.INFO to "Henting av skattekort for batch: 1, type: BESTILLING feilet, men prøvd på nytt senere",
+                                ),
+                            )
                     }
                 }
+            }
+        }
 
-                testAppender.list
-                    .map { it.level to it.message }
-                    .shouldContainExactlyInAnyOrder(
-                        listOf(
-                            Level.INFO to "Henter skattekort for ref1",
-                            Level.INFO to "Henting av skattekort for batch: 1, type: BESTILLING feilet, men prøvd på nytt senere",
+        Given("to batcher hvor den første er FEILET og den andre er NY") {
+            When("bestillingsbatcher hentes") {
+                coEvery { skatteetatenClient.hentSkattekort(any()) } returns
+                    aHentSkattekortResponse(
+                        anArbeidstaker(
+                            resultat = IkkeSkattekort,
+                            fnr = "02020200002",
+                            inntektsaar = 2025,
                         ),
                     )
-            }
-        }
 
-        test("plukker ikke opp batch med status FEILET men tar den andre istedenfor") {
-            coEvery { skatteetatenClient.hentSkattekort(any()) } returns
-                aHentSkattekortResponse(
-                    anArbeidstaker(
-                        resultat = IkkeSkattekort,
-                        fnr = "02020200002",
-                        inntektsaar = 2025,
-                    ),
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    aPerson(2L),
+                    afoedselsnummer(personId = 2L, fnr = "02020200002"),
+                    aPerson(3L),
+                    afoedselsnummer(personId = 3L, fnr = "03030300003"),
+                    aBestillingsbatch(id = 1L, ref = "ref1", status = FEILET),
+                    aBestillingsbatch(id = 2L, ref = "ref2", status = NY),
+                    aBestilling(personId = 1L, fnr = "01010100001", inntektsaar = 2025, batchId = 1L),
+                    aBestilling(personId = 2L, fnr = "02020200002", inntektsaar = 2025, batchId = 2L),
                 )
 
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                aPerson(2L),
-                afoedselsnummer(personId = 2L, fnr = "02020200002"),
-                aPerson(3L),
-                afoedselsnummer(personId = 3L, fnr = "03030300003"),
-                aBestillingsbatch(id = 1L, ref = "ref1", status = FEILET),
-                aBestillingsbatch(id = 2L, ref = "ref2", status = NY),
-                aBestilling(personId = 1L, fnr = "01010100001", inntektsaar = 2025, batchId = 1L),
-                aBestilling(personId = 2L, fnr = "02020200002", inntektsaar = 2025, batchId = 2L),
-            )
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
 
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+                val updatedBatches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
+                val bestillingsAfter: List<Bestilling> = tx(DBTestUtils::getAllBestilling)
+                val person: Person = tx { PersonRepository.findPersonById(it, PersonId(1L)) }
 
-            val updatedBatches: List<Bestillingsbatch> = tx(DBTestUtils::getAllBestillingsbatch)
-            val bestillingsAfter: List<Bestilling> = tx(DBTestUtils::getAllBestilling)
-            val person: Person = tx { PersonRepository.findPersonById(it, PersonId(1L)) }
+                Then("den feilede batchen ignoreres og den nye batchen behandles") {
+                    assertSoftly {
+                        bestillingsAfter shouldNotBeNull {
+                            size shouldBe 1
+                            first().bestillingsbatchId!!.id shouldBe 1L
+                        }
 
-            assertSoftly {
-                bestillingsAfter shouldNotBeNull {
-                    size shouldBe 1
-                    first().bestillingsbatchId!!.id shouldBe 1L
-                }
-
-                updatedBatches shouldNotBeNull {
-                    first().status shouldBe FEILET
-                    last().status shouldBe FERDIG
-                }
-                person shouldNotBeNull {
-                    flagget shouldBe false
+                        updatedBatches shouldNotBeNull {
+                            first().status shouldBe FEILET
+                            last().status shouldBe FERDIG
+                        }
+                        person shouldNotBeNull {
+                            flagget shouldBe false
+                        }
+                    }
                 }
             }
         }
 
-        test("UgyldigOrganisasjonsnummer skal markere batch som FEILET og auditlogger") {
-            coEvery { skatteetatenClient.hentSkattekort(any()) } returns
-                aHentSkattekortResponse(
-                    anArbeidstaker(
-                        resultat = ResultatForSkattekort.UgyldigOrganisasjonsnummer,
-                        fnr = "01010100001",
-                        inntektsaar = 2025,
-                    ),
-                )
-
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-                aBestillingsbatch(1L, "ref1", NY),
-                aBestilling(1L, "01010100001", 2025, 1L),
-            )
-
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
-
-            val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
-            val audit: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
-            val bestillingListAfter = tx(DBTestUtils::getAllBestilling)
-
-            assertSoftly {
-                bestillingsbatchList shouldNotBeNull {
-                    size shouldBe 1
-                    first().status shouldBe FEILET
-                }
-
-                audit shouldNotBeNull {
-                    size shouldBe 1
-                    first().tag shouldBe AuditTag.HENTING_AV_SKATTEKORT_FEILET
-                }
-
-                bestillingListAfter shouldNotBeNull {
-                    size shouldBe 1
-                    first().bestillingsbatchId?.id shouldBe 1L
-                }
-
-                testAppender.list
-                    .map { it.level to it.message }
-                    .shouldContainExactlyInAnyOrder(
-                        listOf(
-                            Level.INFO to "Henter skattekort for ref1",
-                            Level.INFO to "Ved henting av skattekort for batch 1 returnerte Skatteetaten FORESPOERSEL_OK",
-                            Level.ERROR to "Ugydlig organisasjonsnummer av skattekort for batch 1 feilet. Ugyldig organisasjonsnummer",
-                            Level.ERROR to "Henting av skattekort for batch 1 feilet med Ugyldig organisasjonsnummer, sjekk TEAM LOGS for detaljer",
+        Given("en ny batch hvor Skatteetaten returnerer ugyldig organisasjonsnummer") {
+            When("bestillingsbatcher hentes") {
+                coEvery { skatteetatenClient.hentSkattekort(any()) } returns
+                    aHentSkattekortResponse(
+                        anArbeidstaker(
+                            resultat = ResultatForSkattekort.UgyldigOrganisasjonsnummer,
+                            fnr = "01010100001",
+                            inntektsaar = 2025,
                         ),
                     )
-            }
-        }
 
-        test("UgyldigFoedselsEllerDnummer skal markere batch som FERDIG og auditlogger") {
-            coEvery { skatteetatenClient.hentSkattekort(any()) } returns
-                aHentSkattekortResponse(
-                    anArbeidstaker(
-                        resultat = ResultatForSkattekort.UgyldigFoedselsEllerDnummer,
-                        fnr = "01010100001",
-                        inntektsaar = 2025,
-                    ),
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                    aBestillingsbatch(1L, "ref1", NY),
+                    aBestilling(1L, "01010100001", 2025, 1L),
                 )
 
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-                aBestillingsbatch(1L, "ref1", NY),
-                aBestilling(1L, "01010100001", 2025, 1L),
-            )
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
 
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+                val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+                val audit: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
+                val bestillingListAfter = tx(DBTestUtils::getAllBestilling)
 
-            val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
-            val audit: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
-            val bestillingListAfter = tx(DBTestUtils::getAllBestilling)
-            val person: Person = tx { PersonRepository.findPersonById(it, PersonId(1L)) }
-            val skattekortDataList = tx { SkattekortDataRepository.getUnprocessedSkattekortData(it) }
+                Then("batchen markeres som feilet og auditlogg opprettes") {
+                    assertSoftly {
+                        bestillingsbatchList shouldNotBeNull {
+                            size shouldBe 1
+                            first().status shouldBe FEILET
+                        }
 
-            assertSoftly {
-                bestillingsbatchList shouldNotBeNull {
-                    size shouldBe 1
-                    first().status shouldBe FERDIG
+                        audit shouldNotBeNull {
+                            size shouldBe 1
+                            first().tag shouldBe AuditTag.HENTING_AV_SKATTEKORT_FEILET
+                        }
+
+                        bestillingListAfter shouldNotBeNull {
+                            size shouldBe 1
+                            first().bestillingsbatchId?.id shouldBe 1L
+                        }
+
+                        testAppender.list
+                            .map { it.level to it.message }
+                            .shouldContainExactlyInAnyOrder(
+                                listOf(
+                                    Level.INFO to "Henter skattekort for ref1",
+                                    Level.INFO to "Ved henting av skattekort for batch 1 returnerte Skatteetaten FORESPOERSEL_OK",
+                                    Level.ERROR to "Ugydlig organisasjonsnummer av skattekort for batch 1 feilet. Ugyldig organisasjonsnummer",
+                                    Level.ERROR to "Henting av skattekort for batch 1 feilet med Ugyldig organisasjonsnummer, sjekk TEAM LOGS for detaljer",
+                                ),
+                            )
+                    }
                 }
+            }
+        }
 
-                audit shouldNotBeNull {
-                    size shouldBe 1
-                    first().tag shouldBe AuditTag.INVALID_FNR
-                }
-
-                bestillingListAfter shouldBe emptyList()
-
-                person shouldNotBeNull {
-                    flagget shouldBe true
-                }
-
-                skattekortDataList.size shouldBe 1
-
-                testAppender.list
-                    .map { it.level to it.message }
-                    .shouldContainExactlyInAnyOrder(
-                        listOf(
-                            Level.INFO to "Henter skattekort for ref1",
-                            Level.INFO to "Ved henting av skattekort for batch 1 returnerte Skatteetaten FORESPOERSEL_OK",
-                            Level.INFO to "Bestillingsbatch 1 ferdig behandlet med mottatte brukere",
+        Given("en ny batch hvor Skatteetaten returnerer ugyldig fødsels- eller d-nummer") {
+            When("bestillingsbatcher hentes") {
+                coEvery { skatteetatenClient.hentSkattekort(any()) } returns
+                    aHentSkattekortResponse(
+                        anArbeidstaker(
+                            resultat = ResultatForSkattekort.UgyldigFoedselsEllerDnummer,
+                            fnr = "01010100001",
+                            inntektsaar = 2025,
                         ),
                     )
+
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                    aBestillingsbatch(1L, "ref1", NY),
+                    aBestilling(1L, "01010100001", 2025, 1L),
+                )
+
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+
+                val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+                val audit: List<Audit> = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
+                val bestillingListAfter = tx(DBTestUtils::getAllBestilling)
+                val person: Person = tx { PersonRepository.findPersonById(it, PersonId(1L)) }
+                val skattekortDataList = tx { SkattekortDataRepository.getUnprocessedSkattekortData(it) }
+
+                Then("batchen ferdigstilles og personen flagges") {
+                    assertSoftly {
+                        bestillingsbatchList shouldNotBeNull {
+                            size shouldBe 1
+                            first().status shouldBe FERDIG
+                        }
+
+                        audit shouldNotBeNull {
+                            size shouldBe 1
+                            first().tag shouldBe AuditTag.INVALID_FNR
+                        }
+
+                        bestillingListAfter shouldBe emptyList()
+
+                        person shouldNotBeNull {
+                            flagget shouldBe true
+                        }
+
+                        skattekortDataList.size shouldBe 1
+
+                        testAppender.list
+                            .map { it.level to it.message }
+                            .shouldContainExactlyInAnyOrder(
+                                listOf(
+                                    Level.INFO to "Henter skattekort for ref1",
+                                    Level.INFO to "Ved henting av skattekort for batch 1 returnerte Skatteetaten FORESPOERSEL_OK",
+                                    Level.INFO to "Bestillingsbatch 1 ferdig behandlet med mottatte brukere",
+                                ),
+                            )
+                    }
+                }
             }
         }
 
-        test("hentBestillingsbatcher når Skatteetaten-svar ikke er klart ennå (null), skal ikke oppdatere batch") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-                aBestillingsbatch(1, "ref1", NY),
-                aBestilling(1L, "01010100001", 2025, 1L),
-            )
+        Given("en ny batch hvor svaret fra Skatteetaten ennå ikke er klart") {
+            When("bestillingsbatcher hentes og klienten returnerer null") {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                    aBestillingsbatch(1, "ref1", NY),
+                    aBestilling(1L, "01010100001", 2025, 1L),
+                )
 
-            coEvery { skatteetatenClient.hentSkattekort(any()) } returns null
+                coEvery { skatteetatenClient.hentSkattekort(any()) } returns null
 
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
 
-            val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
-            val auditAfter = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
-            val bestillingListAfter = tx(DBTestUtils::getAllBestilling)
+                val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+                val auditAfter = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
+                val bestillingListAfter = tx(DBTestUtils::getAllBestilling)
 
-            assertSoftly {
-                bestillingsbatchList shouldNotBeNull {
-                    size shouldBe 1
-                    first().status shouldBe NY
-                }
-                auditAfter shouldBe emptyList()
-                bestillingListAfter shouldNotBeNull {
-                    size shouldBe 1
-                    first().bestillingsbatchId?.id shouldBe 1L
+                Then("batchen blir stående som ny uten audit eller sletting av bestilling") {
+                    assertSoftly {
+                        bestillingsbatchList shouldNotBeNull {
+                            size shouldBe 1
+                            first().status shouldBe NY
+                        }
+                        auditAfter shouldBe emptyList()
+                        bestillingListAfter shouldNotBeNull {
+                            size shouldBe 1
+                            first().bestillingsbatchId?.id shouldBe 1L
+                        }
+                    }
                 }
             }
         }
 
-        test("hentBestillingsbatcher når circuit breaker er åpen (CallNotPermittedException), skal la batch stå urørt") {
-            databaseHas(
-                aPerson(1L),
-                afoedselsnummer(personId = 1L, fnr = "01010100001"),
-                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
-                aBestillingsbatch(1, "ref1", NY),
-                aBestilling(1L, "01010100001", 2025, 1L),
-            )
+        Given("en ny batch hvor circuit breakeren mot Skatteetaten er åpen") {
+            When("bestillingsbatcher hentes") {
+                databaseHas(
+                    aPerson(1L),
+                    afoedselsnummer(personId = 1L, fnr = "01010100001"),
+                    anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+                    aBestillingsbatch(1, "ref1", NY),
+                    aBestilling(1L, "01010100001", 2025, 1L),
+                )
 
-            val circuitBreaker = CircuitBreaker.of("skatteetaten", CircuitBreakerConfig.ofDefaults())
-            coEvery { skatteetatenClient.hentSkattekort(any()) } throws CallNotPermittedException.createCallNotPermittedException(circuitBreaker)
+                val circuitBreaker = CircuitBreaker.of("skatteetaten", CircuitBreakerConfig.ofDefaults())
+                coEvery { skatteetatenClient.hentSkattekort(any()) } throws CallNotPermittedException.createCallNotPermittedException(circuitBreaker)
 
-            bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
+                bestillingService.hentBestillingsbatcher(BestillingsbatchType.BESTILLING)
 
-            val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
-            val auditAfter = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
+                val bestillingsbatchList = tx(DBTestUtils::getAllBestillingsbatch)
+                val auditAfter = tx { AuditRepository.getAuditByPersonId(it, PersonId(1L)) }
 
-            assertSoftly {
-                bestillingsbatchList shouldNotBeNull {
-                    size shouldBe 1
-                    first().status shouldBe NY
+                Then("batchen blir stående urørt uten audit") {
+                    assertSoftly {
+                        bestillingsbatchList shouldNotBeNull {
+                            size shouldBe 1
+                            first().status shouldBe NY
+                        }
+                        auditAfter shouldBe emptyList()
+                    }
                 }
-                auditAfter shouldBe emptyList()
             }
         }
     })

--- a/src/test/kotlin/no/nav/sokos/skattekort/skattekorthenting/StatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/skattekorthenting/StatusServiceTest.kt
@@ -1,6 +1,6 @@
 package no.nav.sokos.skattekort.skattekorthenting
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 
 import no.nav.sokos.skattekort.listener.DbListener
@@ -18,7 +18,7 @@ import no.nav.sokos.skattekort.skattekortbestilling.Status
 import no.nav.sokos.skattekort.skattekortbestilling.StatusService
 
 class StatusServiceTest :
-    FunSpec(
+    BehaviorSpec(
         {
             extensions(DbListener)
 
@@ -28,106 +28,158 @@ class StatusServiceTest :
                 )
             }
 
-            test("Ugyldig fnr. Skal ha status UGYLDIG_FNR") {
-                databaseHas()
+            Given("en forespørsel med ugyldig fødselsnummer") {
+                When("status forespørres") {
+                    databaseHas()
 
-                val status = statusService.statusForespoeresel(fnr = "abc", aar = 2025, forsystem = "TEST")
-                status shouldBe Status.UGYLDIG_FNR
+                    val status = statusService.statusForespoeresel(fnr = "abc", aar = 2025, forsystem = "TEST")
+
+                    Then("status er UGYLDIG_FNR") {
+                        status shouldBe Status.UGYLDIG_FNR
+                    }
+                }
             }
 
-            test("Gyldig fnr men person finnes ikke. Skal ha status IKKE_FORESPURT") {
-                databaseHas()
+            Given("en gyldig forespørsel der personen ikke finnes") {
+                When("status forespørres") {
+                    databaseHas()
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
-                status shouldBe Status.IKKE_FORESPURT
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
+
+                    Then("status er IKKE_FORESPURT") {
+                        status shouldBe Status.IKKE_FORESPURT
+                    }
+                }
             }
 
-            test("Person finnes, men ikke noe annet. Skal ha status IKKE_FORESPURT") {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
-                )
+            Given("en person som finnes uten bestilling eller skattekort") {
+                When("status forespørres") {
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                    )
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
-                status shouldBe Status.IKKE_FORESPURT
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
+
+                    Then("status er IKKE_FORESPURT") {
+                        status shouldBe Status.IKKE_FORESPURT
+                    }
+                }
             }
 
-            test("Person og en bestilling uten batch finnes. Skal ha status IKKE_BESTILT") {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
-                    aBestilling(1L, "01010100001", 2025, null),
-                )
+            Given("en person med bestilling uten batch") {
+                When("status forespørres") {
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aBestilling(1L, "01010100001", 2025, null),
+                    )
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
-                status shouldBe Status.IKKE_BESTILT
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
+
+                    Then("status er IKKE_BESTILT") {
+                        status shouldBe Status.IKKE_BESTILT
+                    }
+                }
             }
 
-            test("Person, bestilling og batch finnes. Skal ha status BESTILT") {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
-                    aBestillingsbatch(1L, ref = "1234", status = NY, type = BESTILLING),
-                    aBestilling(1L, "01010100001", 2025, 1L),
-                )
+            Given("en person med bestilling og batch") {
+                When("status forespørres") {
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aBestillingsbatch(1L, ref = "1234", status = NY, type = BESTILLING),
+                        aBestilling(1L, "01010100001", 2025, 1L),
+                    )
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
-                status shouldBe Status.BESTILT
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
+
+                    Then("status er BESTILT") {
+                        status shouldBe Status.BESTILT
+                    }
+                }
             }
 
-            test("Person og skattekort finnes. Skal ha status UGYLDIG_FORSYSTEM fordi forsystem ikke er i Forsystem-enum") {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
-                    aSkattekort(1L, 1L, 2025),
-                )
+            Given("en person med skattekort og et ugyldig forsystem") {
+                When("status forespørres") {
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aSkattekort(1L, 1L, 2025),
+                    )
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
-                status shouldBe Status.UGYLDIG_FORSYSTEM
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "TEST")
+
+                    Then("status er UGYLDIG_FORSYSTEM") {
+                        status shouldBe Status.UGYLDIG_FORSYSTEM
+                    }
+                }
             }
 
-            test("Person, skattekort og utsending finnes. Skal ha status VENTER_PAA_UTSENDING") {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
-                    aSkattekort(1L, 1L, 2025),
-                    anUtsending("01010100001", 2025, forsystem = "OS"),
-                )
+            Given("en person med skattekort og utsending for riktig forsystem") {
+                When("status forespørres") {
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aSkattekort(1L, 1L, 2025),
+                        anUtsending("01010100001", 2025, forsystem = "OS"),
+                    )
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "OS")
-                status shouldBe Status.VENTER_PAA_UTSENDING
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "OS")
+
+                    Then("status er VENTER_PAA_UTSENDING") {
+                        status shouldBe Status.VENTER_PAA_UTSENDING
+                    }
+                }
             }
 
-            test("Person og skattekort for året før finnes. Skal ha status IKKE_FORESPURT") {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
-                    aSkattekort(1L, 1L, 2025),
-                )
+            Given("en person med skattekort for året før") {
+                When("status forespørres for neste år") {
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aSkattekort(1L, 1L, 2025),
+                    )
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2026, forsystem = "OS")
-                status shouldBe Status.IKKE_FORESPURT
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2026, forsystem = "OS")
+
+                    Then("status er IKKE_FORESPURT") {
+                        status shouldBe Status.IKKE_FORESPURT
+                    }
+                }
             }
-            test("Person og skattekort finnes. Skal ha status SENDT_FORSYSTEM") {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
-                    aSkattekort(1L, 1L, 2025),
-                )
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "OS")
-                status shouldBe Status.SENDT_FORSYSTEM
+            Given("en person med skattekort uten utsending for forespurt forsystem") {
+                When("status forespørres") {
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aSkattekort(1L, 1L, 2025),
+                    )
+
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "OS")
+
+                    Then("status er SENDT_FORSYSTEM") {
+                        status shouldBe Status.SENDT_FORSYSTEM
+                    }
+                }
             }
-            test("Person, skattekort og utsending for et annet forsystem finnes. Skal ha status SENDT_FORSYSTEM") {
-                databaseHas(
-                    aPerson(1L),
-                    afoedselsnummer(1L, "01010100001"),
-                    aSkattekort(1L, 1L, 2025),
-                    anUtsending("01010100001", 2025, forsystem = "THIS_IS_NOT_THE_FORSYSTEM_YOU_ARE_LOOKING_FOR"),
-                )
 
-                val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "OS")
-                status shouldBe Status.SENDT_FORSYSTEM
+            Given("en person med skattekort og utsending for et annet forsystem") {
+                When("status forespørres") {
+                    databaseHas(
+                        aPerson(1L),
+                        afoedselsnummer(1L, "01010100001"),
+                        aSkattekort(1L, 1L, 2025),
+                        anUtsending("01010100001", 2025, forsystem = "THIS_IS_NOT_THE_FORSYSTEM_YOU_ARE_LOOKING_FOR"),
+                    )
+
+                    val status = statusService.statusForespoeresel(fnr = "01010100001", aar = 2025, forsystem = "OS")
+
+                    Then("status er SENDT_FORSYSTEM") {
+                        status shouldBe Status.SENDT_FORSYSTEM
+                    }
+                }
             }
         },
     )

--- a/src/test/kotlin/no/nav/sokos/skattekort/utsending/UtsendingCronJobTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/utsending/UtsendingCronJobTest.kt
@@ -2,7 +2,7 @@ package no.nav.sokos.skattekort.utsending
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.testcontainers.toDataSource
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
@@ -23,7 +23,7 @@ import no.nav.sokos.skattekort.person.PersonId
 import no.nav.sokos.skattekort.util.SQLUtils.transaction
 
 class UtsendingCronJobTest :
-    FunSpec(
+    BehaviorSpec(
         {
             extensions(listOf(MQListener, DbListener))
             val utsendingDareClientService = mockk<UtsendingDareClientService>()
@@ -38,77 +38,95 @@ class UtsendingCronJobTest :
                 )
             val auditService = AuditService(DbListener.dataSource)
 
-            test("Vi skal kunne sende ut et skattekort til oppdragz") {
-                DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
-                DbListener.loadDataSet("database/utsending/skattekort_oppdragz.sql")
-                uut.handleUtsending()
-                val auditEntries: List<Audit> = auditService.getAuditByPersonId(PersonId(3))
-                auditEntries.map { it.tag } shouldContain (AuditTag.UTSENDING_OK)
-                val messages = JmsTestUtil.getMessages(MQListener.utsendingsQueue)
-                messages.size shouldBe 1
-                messages.first() shouldContain "03030312345"
-                val utsendinger = uut.getAllUtsendinger()
-                utsendinger.size shouldBe 0
-            }
+            Given("et skattekort klart for utsending til oppdragz") {
+                When("utsending håndteres") {
+                    DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
+                    DbListener.loadDataSet("database/utsending/skattekort_oppdragz.sql")
+                    uut.handleUtsending()
+                    val auditEntries: List<Audit> = auditService.getAuditByPersonId(PersonId(3))
+                    val messages = JmsTestUtil.getMessages(MQListener.utsendingsQueue)
+                    val utsendinger = uut.getAllUtsendinger()
 
-            test("Vi skal håndtere feil i utsendelse til oppdragz") {
-                DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
-                DbListener.loadDataSet("database/utsending/skattekort_oppdragz.sql")
-                DbListener.container.toDataSource().connection.use { connection ->
-                    connection.createStatement().use { statement ->
-                        statement.execute("UPDATE forskuddstrekk SET trekk_kode='foobar' WHERE id=5") // Vil ikke eksistere i Trekkode-enumen
-                    }
-                }
-                uut.handleUtsending()
-                val auditEntries: List<Audit> = auditService.getAuditByPersonId(PersonId(3))
-                auditEntries.map { it.tag } shouldContain (AuditTag.UTSENDING_FEILET)
-                val messages = JmsTestUtil.getMessages(MQListener.utsendingsQueue)
-                messages.size shouldBe 0
-                val utsendinger = uut.getAllUtsendinger()
-                withClue("Skal ha en utsending") { utsendinger.size shouldBe 1 }
-                withClue("Skal ha failcount på en") { utsendinger[0].failCount shouldBe 1 }
-            }
-
-            test("utsending skal produsere eksakt copybook-format og lagre bevis i bevis_sending") {
-                DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
-                DbListener.loadDataSet("database/utsending/skattekort_oppdragz.sql")
-
-                uut.handleUtsending()
-
-                val expectedCopybook =
-                    "03030312345skattekortopplysningerOK                20252025-11-1119        kildeskattpensjonist                              1TrekkprosentpensjonFraNAV                                              018,50       12,0"
-
-                val messages = JmsTestUtil.getMessages(MQListener.utsendingsQueue)
-                assertSoftly {
-                    messages shouldHaveSize 1
-                    messages.first() shouldBe expectedCopybook
-                }
-
-                DbListener.dataSource.transaction { tx ->
-                    val sendinger =
-                        tx.list(
-                            queryOf("SELECT sending FROM bevis_sending"),
-                        ) { row -> row.string("sending") }
-                    assertSoftly {
-                        sendinger shouldHaveSize 1
-                        sendinger.first() shouldBe expectedCopybook
+                    Then("skattekortet sendes til oppdragz og utsendingen fjernes") {
+                        auditEntries.map { it.tag } shouldContain (AuditTag.UTSENDING_OK)
+                        messages.size shouldBe 1
+                        messages.first() shouldContain "03030312345"
+                        utsendinger.size shouldBe 0
                     }
                 }
             }
 
-            test("utsending skal rute til stor-kø når forsystem er OS_STOR") {
-                DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
-                DbListener.loadDataSet("database/utsending/skattekort_oppdragz_stor.sql")
+            Given("et skattekort klart for utsending til oppdragz med ugyldig trekkode") {
+                When("utsending håndteres") {
+                    DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
+                    DbListener.loadDataSet("database/utsending/skattekort_oppdragz.sql")
+                    DbListener.container.toDataSource().connection.use { connection ->
+                        connection.createStatement().use { statement ->
+                            statement.execute("UPDATE forskuddstrekk SET trekk_kode='foobar' WHERE id=5")
+                        }
+                    }
+                    uut.handleUtsending()
+                    val auditEntries: List<Audit> = auditService.getAuditByPersonId(PersonId(3))
+                    val messages = JmsTestUtil.getMessages(MQListener.utsendingsQueue)
+                    val utsendinger = uut.getAllUtsendinger()
 
-                uut.handleUtsending()
+                    Then("feilen håndteres uten å sende melding og failcount økes") {
+                        auditEntries.map { it.tag } shouldContain (AuditTag.UTSENDING_FEILET)
+                        messages.size shouldBe 0
+                        withClue("Skal ha en utsending") { utsendinger.size shouldBe 1 }
+                        withClue("Skal ha failcount på en") { utsendinger[0].failCount shouldBe 1 }
+                    }
+                }
+            }
 
-                val messagesNormal = JmsTestUtil.getMessages(MQListener.utsendingsQueue)
-                val messagesStor = JmsTestUtil.getMessages(MQListener.utsendingStorQueue)
+            Given("et skattekort klart for utsending til oppdragz") {
+                When("copybook-format produseres og bevis lagres") {
+                    DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
+                    DbListener.loadDataSet("database/utsending/skattekort_oppdragz.sql")
 
-                assertSoftly {
-                    withClue("Normal kø skal være tom") { messagesNormal shouldHaveSize 0 }
-                    withClue("Stor-kø skal ha én melding") { messagesStor shouldHaveSize 1 }
-                    messagesStor.first() shouldContain "03030312345"
+                    uut.handleUtsending()
+
+                    val expectedCopybook =
+                        "03030312345skattekortopplysningerOK                20252025-11-1119        kildeskattpensjonist                              1TrekkprosentpensjonFraNAV                                              018,50       12,0"
+
+                    val messages = JmsTestUtil.getMessages(MQListener.utsendingsQueue)
+
+                    Then("meldingen får eksakt copybook-format og bevis lagres i bevis_sending") {
+                        assertSoftly {
+                            messages shouldHaveSize 1
+                            messages.first() shouldBe expectedCopybook
+                        }
+                        DbListener.dataSource.transaction { tx ->
+                            val sendinger =
+                                tx.list(
+                                    queryOf("SELECT sending FROM bevis_sending"),
+                                ) { row -> row.string("sending") }
+                            assertSoftly {
+                                sendinger shouldHaveSize 1
+                                sendinger.first() shouldBe expectedCopybook
+                            }
+                        }
+                    }
+                }
+            }
+
+            Given("et skattekort for et forsystem som skal rutes til stor-kø") {
+                When("utsending håndteres") {
+                    DbListener.loadDataSet("database/skattekort/person_med_skattekort.sql")
+                    DbListener.loadDataSet("database/utsending/skattekort_oppdragz_stor.sql")
+
+                    uut.handleUtsending()
+
+                    val messagesNormal = JmsTestUtil.getMessages(MQListener.utsendingsQueue)
+                    val messagesStor = JmsTestUtil.getMessages(MQListener.utsendingStorQueue)
+
+                    Then("normal kø er tom og stor-kø mottar meldingen") {
+                        assertSoftly {
+                            withClue("Normal kø skal være tom") { messagesNormal shouldHaveSize 0 }
+                            withClue("Stor-kø skal ha én melding") { messagesStor shouldHaveSize 1 }
+                            messagesStor.first() shouldContain "03030312345"
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Summary

Konverterer 17 testfiler fra Kotest `FunSpec` til `BehaviorSpec` med norsk Given/When/Then-struktur.

## Hvorfor BDD-tester (BehaviorSpec)?

### Lesbarhet som dokumentasjon
FunSpec-tester har flate testnavn som `"should return person when found"`. BehaviorSpec strukturerer dette som:

```kotlin
Given("en person finnes i PDL") {
    When("vi henter personen") {
        Then("returnerer persondata med navn og ident") { ... }
    }
}
```

Dette gjør at testene fungerer som **levende spesifikasjon** — enhver utvikler kan lese testene og forstå systemets oppførsel uten å lese implementasjonen.

### Tydelig separasjon av forutsetninger, handling og verifikasjon
- **Given** — oppsett/forutsetninger (mocks, testdata)
- **When** — handlingen som testes
- **Then** — forventet resultat

Dette tvinger frem god teststruktur og gjør det åpenbart hva som er testens scope.

### Bedre feilmeldinger og navigering
Når en BehaviorSpec-test feiler, viser Kotest hele kontekst-stien:
```
Given: skatteetaten returnerer feil → When: vi henter skattekort → Then: kaster exception
```
sammenlignet med FunSpec som bare viser testnavnet.

### Gruppering av relaterte scenarier
BehaviorSpec lar oss naturlig gruppere flere Then-assertions under samme Given/When, noe som reduserer duplisert oppsett og gjør det lettere å se alle mulige utfall av én handling.

## Hva er IKKE endret

4 filer beholdt som FunSpec (per prosjektkonvensjon for trivielle/tekniske enhetstester):
- `UnleashIntegrationTest` — enkle boolean-sjekker
- `ReglerForInntektsaarTest` — ren datoberegningslogikk
- `SkattekortFixedRecordFormatterTest` — ren serialiseringsverifikasjon
- `FoedselsnummerkategoriTest` — ren valideringslogikk

## Verifisering

- ✅ Alle tester passerer (`BUILD SUCCESSFUL`)
- ✅ Ktlint — ingen violations
- ✅ Ingen funksjonelle endringer — kun teststruktur