### PR TITLE
refactor: annoter SQL-strenger i repositories med @Language("PostgreS…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,11 +59,8 @@ val avro4kVersion = "2.6.0"
 val graphqlClientVersion = "9.2.0"
 val wiremockVersion = "3.13.2"
 val unleashedVersion = "12.2.1"
-val annotationsVersion = "23.0.0"
 
 dependencies {
-
-    compileOnly("org.jetbrains:annotations:$annotationsVersion")
 
     // Ktor server
     implementation("io.ktor:ktor-server-call-logging-jvm:$ktorVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,8 +59,11 @@ val avro4kVersion = "2.6.0"
 val graphqlClientVersion = "9.2.0"
 val wiremockVersion = "3.13.2"
 val unleashedVersion = "12.2.1"
+val annotationsVersion = "23.0.0"
 
 dependencies {
+
+    compileOnly("org.jetbrains:annotations:$annotationsVersion")
 
     // Ktor server
     implementation("io.ktor:ktor-server-call-logging-jvm:$ktorVersion")

--- a/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/AbonnementRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/AbonnementRepository.kt
@@ -3,7 +3,6 @@ package no.nav.sokos.skattekort.forespoersel
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.person.Foedselsnummer
 import no.nav.sokos.skattekort.person.FoedselsnummerId
@@ -18,7 +17,7 @@ object AbonnementRepository {
         inntektsaar: Int,
         personId: Long,
     ): Long? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             |INSERT INTO abonnementer (forespoersel_id, person_id, inntektsaar)
@@ -37,7 +36,7 @@ object AbonnementRepository {
     }
 
     fun getAllAbonnementer(tx: TransactionalSession): List<Abonnement> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             |SELECT fs.id, fs.forespoersel_id, f.forsystem, f.opprettet, fs.inntektsaar, p.id AS person_id, p.flagget, pf.id AS person_fnr_id, pf.fnr, pf.gjelder_fom
@@ -63,7 +62,7 @@ object AbonnementRepository {
         personId: PersonId,
         inntektsaar: Int,
     ): List<Pair<Forsystem, Personidentifikator>> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT DISTINCT f.forsystem as forsystem,

--- a/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/AbonnementRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/AbonnementRepository.kt
@@ -3,6 +3,7 @@ package no.nav.sokos.skattekort.forespoersel
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.person.Foedselsnummer
 import no.nav.sokos.skattekort.person.FoedselsnummerId
@@ -16,13 +17,16 @@ object AbonnementRepository {
         forespoerselId: Long,
         inntektsaar: Int,
         personId: Long,
-    ): Long? =
-        tx.updateAndReturnGeneratedKey(
+    ): Long? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            |INSERT INTO abonnementer (forespoersel_id, person_id, inntektsaar)
+            |VALUES (:forespoerselId, :personId, :inntektsaar)
+            """.trimMargin()
+        return tx.updateAndReturnGeneratedKey(
             queryOf(
-                """
-                |INSERT INTO abonnementer (forespoersel_id, person_id, inntektsaar)
-                |VALUES (:forespoerselId, :personId, :inntektsaar)
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "forespoerselId" to forespoerselId,
                     "personId" to personId,
@@ -30,49 +34,55 @@ object AbonnementRepository {
                 ),
             ),
         )
+    }
 
-    fun getAllAbonnementer(tx: TransactionalSession): List<Abonnement> =
-        tx.list(
-            queryOf(
-                """
-                |SELECT fs.id, fs.forespoersel_id, f.forsystem, f.opprettet, fs.inntektsaar, p.id AS person_id, p.flagget, pf.id AS person_fnr_id, pf.fnr, pf.gjelder_fom
-                |FROM abonnementer fs
-                |LEFT JOIN forespoersler f ON f.id = fs.forespoersel_id
-                |LEFT JOIN personer p ON p.id = fs.person_id
-                |LEFT JOIN LATERAL (
-                |   SELECT id, gjelder_fom, fnr
-                |   FROM foedselsnumre
-                |   WHERE person_id = p.id
-                |   ORDER BY gjelder_fom DESC, id DESC
-                |   LIMIT 1
-                |) pf ON TRUE 
-                """.trimMargin(),
-            ),
+    fun getAllAbonnementer(tx: TransactionalSession): List<Abonnement> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            |SELECT fs.id, fs.forespoersel_id, f.forsystem, f.opprettet, fs.inntektsaar, p.id AS person_id, p.flagget, pf.id AS person_fnr_id, pf.fnr, pf.gjelder_fom
+            |FROM abonnementer fs
+            |LEFT JOIN forespoersler f ON f.id = fs.forespoersel_id
+            |LEFT JOIN personer p ON p.id = fs.person_id
+            |LEFT JOIN LATERAL (
+            |   SELECT id, gjelder_fom, fnr
+            |   FROM foedselsnumre
+            |   WHERE person_id = p.id
+            |   ORDER BY gjelder_fom DESC, id DESC
+            |   LIMIT 1
+            |) pf ON TRUE
+            """.trimMargin()
+        return tx.list(
+            queryOf(sql),
             mapToAbonnement,
         )
+    }
 
     fun findForsystemAndFnr(
         tx: TransactionalSession,
         personId: PersonId,
         inntektsaar: Int,
-    ): List<Pair<Forsystem, Personidentifikator>> =
-        tx.list(
+    ): List<Pair<Forsystem, Personidentifikator>> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT DISTINCT f.forsystem as forsystem,
+                            (SELECT fn.fnr
+                             FROM abonnementer a
+                                      INNER JOIN forespoersler f ON f.id = a.forespoersel_id
+                                      INNER JOIN foedselsnumre fn ON a.person_id = fn.person_id
+                             WHERE a.person_id = :personId
+                               AND f.data_mottatt LIKE '%' || fn.fnr || '%'
+                             order by f.id desc
+                             limit 1) as fnr
+            FROM abonnementer a
+                     JOIN forespoersler f ON f.id = a.forespoersel_id
+            WHERE a.person_id = :personId
+              AND a.inntektsaar = :inntektsaar;
+            """.trimIndent()
+        return tx.list(
             queryOf(
-                """
-                SELECT DISTINCT f.forsystem as forsystem,
-                                (SELECT fn.fnr
-                                 FROM abonnementer a
-                                          INNER JOIN forespoersler f ON f.id = a.forespoersel_id
-                                          INNER JOIN foedselsnumre fn ON a.person_id = fn.person_id
-                                 WHERE a.person_id = :personId
-                                   AND f.data_mottatt LIKE '%' || fn.fnr || '%'
-                                 order by f.id desc
-                                 limit 1) as fnr
-                FROM abonnementer a
-                         JOIN forespoersler f ON f.id = a.forespoersel_id
-                WHERE a.person_id = :personId
-                  AND a.inntektsaar = :inntektsaar;
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "personId" to personId.value,
                     "inntektsaar" to inntektsaar,
@@ -82,6 +92,7 @@ object AbonnementRepository {
                 Pair(Forsystem.fromValue(row.string("forsystem")), Personidentifikator(row.string("fnr")))
             },
         )
+    }
 
     private val mapToAbonnement: (Row) -> Abonnement = { row ->
         Abonnement(

--- a/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselRepository.kt
@@ -3,58 +3,70 @@ package no.nav.sokos.skattekort.forespoersel
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 object ForespoerselRepository {
     fun insert(
         tx: TransactionalSession,
         forsystem: Forsystem,
         dataMottatt: String,
-    ): Long =
-        tx.updateAndReturnGeneratedKey(
+    ): Long {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            INSERT INTO forespoersler (forsystem, data_mottatt)
+            VALUES (:forsystem, :data_mottatt)
+            """.trimIndent()
+        return tx.updateAndReturnGeneratedKey(
             queryOf(
-                """
-                INSERT INTO forespoersler (forsystem, data_mottatt)
-                VALUES (:forsystem, :data_mottatt)
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "forsystem" to forsystem.value,
                     "data_mottatt" to dataMottatt,
                 ),
             ),
         ) ?: throw IllegalStateException("Failed to insert forespoersel")
+    }
 
     fun getAllForespoersel(
         tx: TransactionalSession,
         count: Int = 1000,
         offset: Int = 0,
-    ): List<Forespoersel> =
-        tx.list(
+    ): List<Forespoersel> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT * FROM forespoersler
+            ORDER BY id ASC
+            LIMIT :count OFFSET :offset
+            """.trimIndent()
+        return tx.list(
             queryOf(
-                """
-                SELECT * FROM forespoersler
-                ORDER BY id ASC
-                LIMIT :count OFFSET :offset
-                """.trimIndent(),
+                sql,
                 mapOf("count" to count, "offset" to offset),
             ),
             mapToForespoersel,
         )
+    }
 
-    fun getAllForespoerselInput(tx: TransactionalSession): List<ForespoerselInput> =
-        tx.list(
-            queryOf(
-                """
-                SELECT * FROM forespoersel_input
-                """.trimIndent(),
-            ),
+    fun getAllForespoerselInput(tx: TransactionalSession): List<ForespoerselInput> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT * FROM forespoersel_input
+            """.trimIndent()
+        return tx.list(
+            queryOf(sql),
             mapToForespoerselInput,
         )
+    }
 
     fun deleteAllForespoerselInput(tx: TransactionalSession) {
+        @Language("PostgreSQL")
+        val sql =
+            "DELETE FROM forespoersel_input"
         tx.update(
-            queryOf(
-                """DELETE FROM forespoersel_input""",
-            ),
+            queryOf(sql),
         )
     }
 

--- a/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselRepository.kt
@@ -3,7 +3,6 @@ package no.nav.sokos.skattekort.forespoersel
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 object ForespoerselRepository {
     fun insert(
@@ -11,7 +10,7 @@ object ForespoerselRepository {
         forsystem: Forsystem,
         dataMottatt: String,
     ): Long {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             INSERT INTO forespoersler (forsystem, data_mottatt)
@@ -33,7 +32,7 @@ object ForespoerselRepository {
         count: Int = 1000,
         offset: Int = 0,
     ): List<Forespoersel> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT * FROM forespoersler
@@ -50,7 +49,7 @@ object ForespoerselRepository {
     }
 
     fun getAllForespoerselInput(tx: TransactionalSession): List<ForespoerselInput> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT * FROM forespoersel_input
@@ -62,7 +61,7 @@ object ForespoerselRepository {
     }
 
     fun deleteAllForespoerselInput(tx: TransactionalSession) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             "DELETE FROM forespoersel_input"
         tx.update(

--- a/src/main/kotlin/no/nav/sokos/skattekort/person/AuditRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/person/AuditRepository.kt
@@ -2,6 +2,7 @@ package no.nav.sokos.skattekort.person
 
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 object AuditRepository {
     fun insert(
@@ -10,13 +11,16 @@ object AuditRepository {
         personId: PersonId,
         informasjon: String,
         brukerId: String? = null,
-    ): Long? =
-        tx.updateAndReturnGeneratedKey(
+    ): Long? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            INSERT INTO person_audit(person_id, tag, bruker_id, informasjon)
+            VALUES (:person_id, :tag, :brukerId, :informasjon)
+            """.trimIndent()
+        return tx.updateAndReturnGeneratedKey(
             queryOf(
-                """
-                INSERT INTO person_audit(person_id, tag, bruker_id, informasjon)
-                VALUES (:person_id, :tag, :brukerId, :informasjon)
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "person_id" to personId.value,
                     "tag" to tag.name,
@@ -25,6 +29,7 @@ object AuditRepository {
                 ),
             ),
         )
+    }
 
     fun insertBatch(
         tx: TransactionalSession,
@@ -32,35 +37,44 @@ object AuditRepository {
         personIds: List<PersonId>,
         informasjon: String,
         brukerId: String? = null,
-    ) = tx.batchPreparedNamedStatementAndReturnGeneratedKeys(
-        """
-        INSERT INTO person_audit(person_id, tag, bruker_id, informasjon)
-        VALUES (:person_id, :tag, :brukerId, :informasjon)
-        """.trimIndent(),
-        personIds.map { personId ->
-            mapOf(
-                "person_id" to personId.value,
-                "tag" to tag.name,
-                "brukerId" to (brukerId ?: AUDIT_SYSTEM),
-                "informasjon" to informasjon,
-            )
-        },
-    )
+    ) = run {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            INSERT INTO person_audit(person_id, tag, bruker_id, informasjon)
+            VALUES (:person_id, :tag, :brukerId, :informasjon)
+            """.trimIndent()
+        tx.batchPreparedNamedStatementAndReturnGeneratedKeys(
+            sql,
+            personIds.map { personId ->
+                mapOf(
+                    "person_id" to personId.value,
+                    "tag" to tag.name,
+                    "brukerId" to (brukerId ?: AUDIT_SYSTEM),
+                    "informasjon" to informasjon,
+                )
+            },
+        )
+    }
 
     fun getAuditByPersonId(
         tx: TransactionalSession,
         personId: PersonId,
-    ): List<Audit> =
-        tx.list(
+    ): List<Audit> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT id, person_id, bruker_id, opprettet, tag, informasjon
+            FROM person_audit
+            WHERE person_id = :personId
+            ORDER BY id
+            """.trimIndent()
+        return tx.list(
             queryOf(
-                """
-                SELECT id, person_id, bruker_id, opprettet, tag, informasjon
-                FROM person_audit
-                WHERE person_id = :personId
-                ORDER BY id
-                """.trimIndent(),
+                sql,
                 mapOf("personId" to personId.value),
             ),
             extractor = { row -> Audit(row) },
         )
+    }
 }

--- a/src/main/kotlin/no/nav/sokos/skattekort/person/AuditRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/person/AuditRepository.kt
@@ -2,7 +2,6 @@ package no.nav.sokos.skattekort.person
 
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 object AuditRepository {
     fun insert(
@@ -12,7 +11,7 @@ object AuditRepository {
         informasjon: String,
         brukerId: String? = null,
     ): Long? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             INSERT INTO person_audit(person_id, tag, bruker_id, informasjon)
@@ -38,7 +37,7 @@ object AuditRepository {
         informasjon: String,
         brukerId: String? = null,
     ) = run {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             INSERT INTO person_audit(person_id, tag, bruker_id, informasjon)
@@ -61,7 +60,7 @@ object AuditRepository {
         tx: TransactionalSession,
         personId: PersonId,
     ): List<Audit> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT id, person_id, bruker_id, opprettet, tag, informasjon

--- a/src/main/kotlin/no/nav/sokos/skattekort/person/FoedselsnummerRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/person/FoedselsnummerRepository.kt
@@ -2,18 +2,22 @@ package no.nav.sokos.skattekort.person
 
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 object FoedselsnummerRepository {
     fun insert(
         tx: TransactionalSession,
         foedselsnummer: Foedselsnummer,
-    ): Long? =
-        tx.updateAndReturnGeneratedKey(
+    ): Long? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            INSERT INTO foedselsnumre (person_id, gjelder_fom, fnr)
+            VALUES (:personId, :gjelderFom, :fnr)
+            """.trimIndent()
+        return tx.updateAndReturnGeneratedKey(
             queryOf(
-                """
-                INSERT INTO foedselsnumre (person_id, gjelder_fom, fnr) 
-                VALUES (:personId, :gjelderFom, :fnr)
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "personId" to foedselsnummer.personId?.value,
                     "gjelderFom" to foedselsnummer.gjelderFom,
@@ -21,37 +25,45 @@ object FoedselsnummerRepository {
                 ),
             ),
         )
+    }
 
     fun insertByExistingFnr(
         tx: TransactionalSession,
         fnr: String,
         existingFnr: String,
-    ): Long? =
-        tx.updateAndReturnGeneratedKey(
+    ): Long? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            INSERT INTO foedselsnumre (person_id, gjelder_fom, fnr)
+            SELECT person_id, gjelder_fom - INTERVAL '1 day', :fnr FROM foedselsnumre WHERE fnr = :existingFnr
+            """.trimIndent()
+        return tx.updateAndReturnGeneratedKey(
             queryOf(
-                """
-                INSERT INTO foedselsnumre (person_id, gjelder_fom, fnr) 
-                SELECT person_id, gjelder_fom - INTERVAL '1 day', :fnr FROM foedselsnumre WHERE fnr = :existingFnr
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "fnr" to fnr,
                     "existingFnr" to existingFnr,
                 ),
             ),
         )
+    }
 
     fun findPersonIdByFnrList(
         tx: TransactionalSession,
         fnrList: List<String>,
     ): Map<String, PersonId?> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT person_id, fnr FROM foedselsnumre
+            WHERE fnr = ANY(?)
+            """.trimIndent()
         val resultMap =
             tx
                 .list(
                     queryOf(
-                        """
-                        SELECT person_id, fnr FROM foedselsnumre
-                        WHERE fnr = ANY(?)
-                        """.trimIndent(),
+                        sql,
                         fnrList.toTypedArray(),
                     ),
                     extractor = { row ->

--- a/src/main/kotlin/no/nav/sokos/skattekort/person/FoedselsnummerRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/person/FoedselsnummerRepository.kt
@@ -2,14 +2,13 @@ package no.nav.sokos.skattekort.person
 
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 object FoedselsnummerRepository {
     fun insert(
         tx: TransactionalSession,
         foedselsnummer: Foedselsnummer,
     ): Long? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             INSERT INTO foedselsnumre (person_id, gjelder_fom, fnr)
@@ -32,7 +31,7 @@ object FoedselsnummerRepository {
         fnr: String,
         existingFnr: String,
     ): Long? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             INSERT INTO foedselsnumre (person_id, gjelder_fom, fnr)
@@ -53,7 +52,7 @@ object FoedselsnummerRepository {
         tx: TransactionalSession,
         fnrList: List<String>,
     ): Map<String, PersonId?> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT person_id, fnr FROM foedselsnumre

--- a/src/main/kotlin/no/nav/sokos/skattekort/person/PersonRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/person/PersonRepository.kt
@@ -5,6 +5,7 @@ import java.time.LocalDate
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.util.SQLUtils.advisoryKeysFromString
 
@@ -12,56 +13,68 @@ object PersonRepository {
     fun findPersonIdByFnr(
         tx: TransactionalSession,
         fnr: Personidentifikator,
-    ): PersonId? =
-        tx.single(
+    ): PersonId? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |SELECT distinct p.id
+                |FROM personer p INNER JOIN foedselsnumre f ON p.id = f.person_id
+                |WHERE f.fnr = :fnr;
+            """.trimMargin()
+        return tx.single(
             queryOf(
-                """
-                    |SELECT distinct p.id 
-                    |FROM personer p INNER JOIN foedselsnumre f ON p.id = f.person_id 
-                    |WHERE f.fnr = :fnr;
-                """.trimMargin(),
+                sql,
                 mapOf("fnr" to fnr.value),
             ),
         ) { row -> PersonId(row.long("id")) }
+    }
 
     fun findPersonById(
         tx: TransactionalSession,
         personId: PersonId,
-    ): Person =
-        tx.single(
+    ): Person {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |SELECT p.id as person_id, p.flagget, pf.id as foedselsnummer_id, pf.gjelder_fom, pf.fnr
+                |FROM personer p
+                |LEFT JOIN LATERAL (
+                |   SELECT id, gjelder_fom, fnr
+                |   FROM foedselsnumre
+                |   WHERE person_id = p.id
+                |   ORDER BY gjelder_fom DESC, id DESC
+                |   LIMIT 1
+                |) pf ON TRUE
+                |WHERE p.id = :personId
+            """.trimMargin()
+        return tx.single(
             queryOf(
-                """
-                    |SELECT p.id as person_id, p.flagget, pf.id as foedselsnummer_id, pf.gjelder_fom, pf.fnr
-                    |FROM personer p 
-                    |LEFT JOIN LATERAL (
-                    |   SELECT id, gjelder_fom, fnr
-                    |   FROM foedselsnumre
-                    |   WHERE person_id = p.id
-                    |   ORDER BY gjelder_fom DESC, id DESC
-                    |   LIMIT 1
-                    |) pf ON TRUE
-                    |WHERE p.id = :personId
-                """.trimMargin(),
+                sql,
                 mapOf("personId" to personId.value),
             ),
             extractor = mapToPerson,
         )!!
+    }
 
     fun findPersonByFnr(
         tx: TransactionalSession,
         fnr: Personidentifikator,
-    ): Person? =
-        tx.single(
+    ): Person? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |SELECT p.id as person_id, p.flagget, pf.id as foedselsnummer_id, pf.gjelder_fom, pf.fnr
+                |FROM personer p JOIN foedselsnumre pf ON p.id = pf.person_id
+                |WHERE pf.fnr = :fnr
+            """.trimMargin()
+        return tx.single(
             queryOf(
-                """
-                    |SELECT p.id as person_id, p.flagget, pf.id as foedselsnummer_id, pf.gjelder_fom, pf.fnr
-                    |FROM personer p JOIN foedselsnumre pf ON p.id = pf.person_id 
-                    |WHERE pf.fnr = :fnr
-                """.trimMargin(),
+                sql,
                 mapOf("fnr" to fnr.value),
             ),
             extractor = mapToPerson,
         )
+    }
 
     /**
      * pg_advisory_xact_lock acquires a transaction-scoped advisory lock in PostgreSQL.
@@ -76,46 +89,53 @@ object PersonRepository {
         brukerId: String? = null,
     ): Long? {
         val (k1, k2) = advisoryKeysFromString(fnr.value)
+
+        @Language("PostgreSQL")
+        val advisoryLockSql =
+            "SELECT pg_advisory_xact_lock(:k1, :k2)"
         tx.execute(
             queryOf(
-                "SELECT pg_advisory_xact_lock(:k1, :k2)",
+                advisoryLockSql,
                 mapOf("k1" to k1, "k2" to k2),
             ),
         )
 
+        @Language("PostgreSQL")
+        val sql =
+            """
+        |WITH existing_foedselsnummer AS (
+        |   SELECT person_id FROM foedselsnumre WHERE fnr = :fnr
+        |),
+        |inserted_person AS (
+        |   INSERT INTO personer (flagget)
+        |   SELECT :flagget
+        |   WHERE NOT EXISTS (SELECT 1 FROM existing_foedselsnummer)
+        |   RETURNING id AS person_id
+        |),
+        |resolved_person AS (
+        |   SELECT COALESCE(
+        |     (SELECT person_id FROM inserted_person),
+        |     (SELECT person_id FROM existing_foedselsnummer)
+        |   ) AS person_id
+        |),
+        |upserted_foedselsnummer AS (
+        |   INSERT INTO foedselsnumre (person_id, gjelder_fom, fnr)
+        |   SELECT person_id, :gjelderFom, :fnr
+        |   FROM resolved_person
+        |   ON CONFLICT (fnr) DO NOTHING
+        |   RETURNING person_id
+        |),
+        |audit_insert AS (
+        |   INSERT INTO person_audit(person_id, bruker_id, opprettet, tag, informasjon)
+        |   SELECT person_id, :brukerId, now(), :tag, :informasjon
+        |   FROM inserted_person
+        |   RETURNING person_id
+        |)
+        |SELECT person_id FROM resolved_person;
+            """.trimMargin()
         return tx.single(
             queryOf(
-                """
-            |WITH existing_foedselsnummer AS (
-            |   SELECT person_id FROM foedselsnumre WHERE fnr = :fnr
-            |),
-            |inserted_person AS (
-            |   INSERT INTO personer (flagget)
-            |   SELECT :flagget
-            |   WHERE NOT EXISTS (SELECT 1 FROM existing_foedselsnummer)
-            |   RETURNING id AS person_id
-            |),
-            |resolved_person AS (
-            |   SELECT COALESCE(
-            |     (SELECT person_id FROM inserted_person),
-            |     (SELECT person_id FROM existing_foedselsnummer)
-            |   ) AS person_id
-            |),
-            |upserted_foedselsnummer AS (
-            |   INSERT INTO foedselsnumre (person_id, gjelder_fom, fnr)
-            |   SELECT person_id, :gjelderFom, :fnr
-            |   FROM resolved_person
-            |   ON CONFLICT (fnr) DO NOTHING
-            |   RETURNING person_id
-            |),
-            |audit_insert AS (
-            |   INSERT INTO person_audit(person_id, bruker_id, opprettet, tag, informasjon)
-            |   SELECT person_id, :brukerId, now(), :tag, :informasjon
-            |   FROM inserted_person
-            |   RETURNING person_id
-            |)
-            |SELECT person_id FROM resolved_person;
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "fnr" to fnr.value,
                     "flagget" to false,
@@ -131,16 +151,21 @@ object PersonRepository {
     fun flaggPerson(
         tx: TransactionalSession,
         personId: PersonId,
-    ) = tx.execute(
-        queryOf(
+    ) {
+        @Language("PostgreSQL")
+        val sql =
             """
-                    |UPDATE personer 
-                    |SET flagget = true
-                    |WHERE id = :personId
-            """.trimMargin(),
-            mapOf("personId" to personId.value),
-        ),
-    )
+                |UPDATE personer
+                |SET flagget = true
+                |WHERE id = :personId
+            """.trimMargin()
+        tx.execute(
+            queryOf(
+                sql,
+                mapOf("personId" to personId.value),
+            ),
+        )
+    }
 
     private val mapToPerson: (Row) -> Person = { row ->
         Person(

--- a/src/main/kotlin/no/nav/sokos/skattekort/person/PersonRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/person/PersonRepository.kt
@@ -5,7 +5,6 @@ import java.time.LocalDate
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.util.SQLUtils.advisoryKeysFromString
 
@@ -14,7 +13,7 @@ object PersonRepository {
         tx: TransactionalSession,
         fnr: Personidentifikator,
     ): PersonId? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |SELECT distinct p.id
@@ -33,7 +32,7 @@ object PersonRepository {
         tx: TransactionalSession,
         personId: PersonId,
     ): Person {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |SELECT p.id as person_id, p.flagget, pf.id as foedselsnummer_id, pf.gjelder_fom, pf.fnr
@@ -60,7 +59,7 @@ object PersonRepository {
         tx: TransactionalSession,
         fnr: Personidentifikator,
     ): Person? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |SELECT p.id as person_id, p.flagget, pf.id as foedselsnummer_id, pf.gjelder_fom, pf.fnr
@@ -90,7 +89,7 @@ object PersonRepository {
     ): Long? {
         val (k1, k2) = advisoryKeysFromString(fnr.value)
 
-        @Language("PostgreSQL")
+        // language=SQL
         val advisoryLockSql =
             "SELECT pg_advisory_xact_lock(:k1, :k2)"
         tx.execute(
@@ -100,7 +99,7 @@ object PersonRepository {
             ),
         )
 
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
         |WITH existing_foedselsnummer AS (
@@ -152,7 +151,7 @@ object PersonRepository {
         tx: TransactionalSession,
         personId: PersonId,
     ) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |UPDATE personer

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import kotliquery.Query
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.person.PersonId
 
@@ -13,14 +14,16 @@ object SkattekortRepository {
         tx: TransactionalSession,
         skattekort: Skattekort,
     ): Long {
+        @Language("PostgreSQL")
+        val insertSkattekortSql =
+            """
+            INSERT INTO skattekort (generert_fra, person_id, utstedt_dato, identifikator, inntektsaar, kilde, resultatForSkattekort) 
+            VALUES (:generertFra, :personId, :utstedtDato, :identifikator, :inntektsaar, :kilde, :resultatForSkattekort)
+            """.trimIndent()
         val id =
             tx.updateAndReturnGeneratedKey(
                 Query(
-                    statement =
-                        """
-                        INSERT INTO skattekort (generert_fra, person_id, utstedt_dato, identifikator, inntektsaar, kilde, resultatForSkattekort) 
-                        VALUES (:generertFra, :personId, :utstedtDato, :identifikator, :inntektsaar, :kilde, :resultatForSkattekort)
-                        """.trimIndent(),
+                    statement = insertSkattekortSql,
                     paramMap =
                         mapOf(
                             "generertFra" to skattekort.generertFra?.value,
@@ -34,11 +37,14 @@ object SkattekortRepository {
                 ),
             )
         if (skattekort.forskuddstrekkList.isNotEmpty()) {
-            tx.batchPreparedNamedStatementAndReturnGeneratedKeys(
+            @Language("PostgreSQL")
+            val insertForskuddstrekkSql =
                 """
                 INSERT INTO forskuddstrekk (skattekort_id, trekk_kode, type, frikort_beloep, tabell_nummer, prosentsats, antall_mnd_for_trekk)
                 VALUES (:skattekortId, :trekk_kode, :type, :frikort_beloep, :tabell_nummer, :prosentsats, :antall_mnd_for_trekk)
-                """.trimIndent(),
+                """.trimIndent()
+            tx.batchPreparedNamedStatementAndReturnGeneratedKeys(
+                insertForskuddstrekkSql,
                 skattekort.forskuddstrekkList.map { forskuddstrekk ->
                     when (forskuddstrekk) {
                         is Frikort -> {
@@ -81,11 +87,14 @@ object SkattekortRepository {
             )
         }
         if (skattekort.tilleggsopplysningList.isNotEmpty()) {
-            tx.batchPreparedNamedStatementAndReturnGeneratedKeys(
+            @Language("PostgreSQL")
+            val insertTilleggsopplysningSql =
                 """
                 INSERT INTO skattekort_tilleggsopplysning (skattekort_id, opplysning)
                 VALUES (:skattekortId, :opplysning)
-                """.trimIndent(),
+                """.trimIndent()
+            tx.batchPreparedNamedStatementAndReturnGeneratedKeys(
+                insertTilleggsopplysningSql,
                 skattekort.tilleggsopplysningList.map { tilleggsopplysning ->
                     mapOf(
                         "skattekortId" to id,
@@ -168,84 +177,91 @@ object SkattekortRepository {
     fun getAllIdByInntektsaar(
         tx: TransactionalSession,
         inntektsaar: Int,
-    ): List<Long> =
-        tx.list(
-            queryOf(
-                """
-                SELECT id FROM skattekort WHERE inntektsaar = :inntektsaar ORDER BY id;
-                """.trimIndent(),
-                mapOf("inntektsaar" to inntektsaar),
-            ),
+    ): List<Long> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT id FROM skattekort WHERE inntektsaar = :inntektsaar ORDER BY id;
+            """.trimIndent()
+        return tx.list(
+            queryOf(sql, mapOf("inntektsaar" to inntektsaar)),
             extractor = { row -> row.long("id") },
         )
+    }
 
     fun deleteBatch(
         tx: TransactionalSession,
         skattekortIdList: List<Long>,
     ) {
+        @Language("PostgreSQL")
+        val sql = "DELETE FROM skattekort WHERE id = :skattekortId"
         tx.batchPreparedNamedStatement(
-            """
-            DELETE FROM skattekort WHERE id = :skattekortId
-            """.trimIndent(),
+            sql,
             skattekortIdList.map { id ->
                 mapOf("skattekortId" to id)
             },
         )
     }
 
-    fun getSecondsSinceLatestSkattekortOpprettet(tx: TransactionalSession): Double? =
-        tx.single(
-            queryOf(
-                """SELECT EXTRACT(EPOCH FROM NOW() - MAX(opprettet)) AS sekunder_siden_siste_skattekort FROM skattekort""",
-            ),
+    fun getSecondsSinceLatestSkattekortOpprettet(tx: TransactionalSession): Double? {
+        @Language("PostgreSQL")
+        val sql = "SELECT EXTRACT(EPOCH FROM NOW() - MAX(opprettet)) AS sekunder_siden_siste_skattekort FROM skattekort"
+        return tx.single(
+            queryOf(sql),
             extractor = { row -> row.doubleOrNull("sekunder_siden_siste_skattekort") },
         )
+    }
 
-    fun numberOfSkattekortByResultatForSkattekortMetrics(tx: TransactionalSession): Map<ResultatForSkattekort, Int> =
-        tx
+    fun numberOfSkattekortByResultatForSkattekortMetrics(tx: TransactionalSession): Map<ResultatForSkattekort, Int> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT resultatForSkattekort, COUNT(1) AS antall 
+            FROM skattekort
+            GROUP BY resultatForSkattekort
+            """.trimIndent()
+        return tx
             .list(
-                queryOf(
-                    """
-                    SELECT resultatForSkattekort, COUNT(1) AS antall 
-                    FROM skattekort
-                    GROUP BY resultatForSkattekort
-                    """.trimIndent(),
-                ),
+                queryOf(sql),
                 extractor = { row ->
                     val resultat = ResultatForSkattekort.fromValue(row.string("resultatForSkattekort"))
                     val count = row.int("antall")
                     resultat to count
                 },
             ).toMap()
+    }
 
-    fun numberOfForskuddstrekkWithTabelltrekkByTrekkodeMetrics(tx: TransactionalSession): Map<String, Int> =
-        tx
+    fun numberOfForskuddstrekkWithTabelltrekkByTrekkodeMetrics(tx: TransactionalSession): Map<String, Int> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT trekk_kode, COUNT(1) AS antall 
+            FROM forskuddstrekk
+            WHERE type = 'trekktabell'
+            GROUP BY trekk_kode
+            """.trimIndent()
+        return tx
             .list(
-                queryOf(
-                    """
-                    SELECT trekk_kode, COUNT(1) AS antall 
-                    FROM forskuddstrekk
-                    WHERE type = 'trekktabell'
-                    GROUP BY trekk_kode
-                    """.trimIndent(),
-                ),
+                queryOf(sql),
                 extractor = { row ->
                     val trekkode = row.string("trekk_kode")
                     val count = row.int("antall")
                     trekkode to count
                 },
             ).toMap()
+    }
 
-    fun numberOfSkattekortByTilleggsopplysningMetrics(tx: TransactionalSession): Map<Tilleggsopplysning, Int> =
-        tx
+    fun numberOfSkattekortByTilleggsopplysningMetrics(tx: TransactionalSession): Map<Tilleggsopplysning, Int> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT opplysning, COUNT(skattekort_id) AS antall 
+            FROM skattekort_tilleggsopplysning
+            GROUP BY opplysning
+            """.trimIndent()
+        return tx
             .list(
-                queryOf(
-                    """
-                    SELECT opplysning, COUNT(skattekort_id) AS antall 
-                    FROM skattekort_tilleggsopplysning
-                    GROUP BY opplysning
-                    """.trimIndent(),
-                ),
+                queryOf(sql),
                 extractor = { row ->
                     val opplysning =
                         Tilleggsopplysning.fromValue(row.string("opplysning"))
@@ -253,44 +269,47 @@ object SkattekortRepository {
                     opplysning to count
                 },
             ).toMap()
+    }
 
-    fun numberOfFrikortMedUtenBeloepsgrense(tx: TransactionalSession): Map<String, Int> =
-        tx
+    fun numberOfFrikortMedUtenBeloepsgrense(tx: TransactionalSession): Map<String, Int> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT 
+               CASE WHEN
+                  frikort_beloep IS NULL OR frikort_beloep = 0 THEN 'Ubegrenset'
+                  ELSE 'Begrenset'
+               END AS begrensning,
+            COUNT(1) AS antall 
+            FROM forskuddstrekk
+            WHERE type = 'frikort'
+            GROUP BY
+              CASE WHEN
+                  frikort_beloep IS NULL OR frikort_beloep = 0 THEN 'Ubegrenset'
+                  ELSE 'Begrenset'
+              END 
+            """.trimIndent()
+        return tx
             .list(
-                queryOf(
-                    """
-                    SELECT 
-                       CASE WHEN
-                          frikort_beloep IS NULL OR frikort_beloep = 0 THEN 'Ubegrenset'
-                          ELSE 'Begrenset'
-                       END AS begrensning,
-                    COUNT(1) AS antall 
-                    FROM forskuddstrekk
-                    WHERE type = 'frikort'
-                    GROUP BY
-                      CASE WHEN
-                          frikort_beloep IS NULL OR frikort_beloep = 0 THEN 'Ubegrenset'
-                          ELSE 'Begrenset'
-                      END 
-                    """.trimIndent(),
-                ),
+                queryOf(sql),
                 extractor = { row ->
                     val type = row.string("begrensning")
                     val count = row.int("antall")
                     type to count
                 },
             ).toMap()
+    }
 
-    fun getNoekkelinformasjon(tx: TransactionalSession): Map<String, Int> =
-        tx
-            .list(
-                queryOf(
-                    """
-            |SELECT inntektsaar::text AS key, COUNT(1) AS antall FROM skattekort GROUP BY inntektsaar
-            |UNION ALL
-            |SELECT 'personer' AS key, COUNT(1) AS antall FROM personer;
-                    """.trimMargin(),
-                ),
-            ) { row -> row.string("key") to row.int("antall") }
+    fun getNoekkelinformasjon(tx: TransactionalSession): Map<String, Int> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT inntektsaar::text AS key, COUNT(1) AS antall FROM skattekort GROUP BY inntektsaar
+            UNION ALL
+            SELECT 'personer' AS key, COUNT(1) AS antall FROM personer;
+            """.trimIndent()
+        return tx
+            .list(queryOf(sql)) { row -> row.string("key") to row.int("antall") }
             .toMap()
+    }
 }

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortRepository.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.json.Json
 import kotliquery.Query
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.person.PersonId
 
@@ -14,7 +13,7 @@ object SkattekortRepository {
         tx: TransactionalSession,
         skattekort: Skattekort,
     ): Long {
-        @Language("PostgreSQL")
+        // language=SQL
         val insertSkattekortSql =
             """
             INSERT INTO skattekort (generert_fra, person_id, utstedt_dato, identifikator, inntektsaar, kilde, resultatForSkattekort) 
@@ -37,7 +36,7 @@ object SkattekortRepository {
                 ),
             )
         if (skattekort.forskuddstrekkList.isNotEmpty()) {
-            @Language("PostgreSQL")
+            // language=SQL
             val insertForskuddstrekkSql =
                 """
                 INSERT INTO forskuddstrekk (skattekort_id, trekk_kode, type, frikort_beloep, tabell_nummer, prosentsats, antall_mnd_for_trekk)
@@ -87,7 +86,7 @@ object SkattekortRepository {
             )
         }
         if (skattekort.tilleggsopplysningList.isNotEmpty()) {
-            @Language("PostgreSQL")
+            // language=SQL
             val insertTilleggsopplysningSql =
                 """
                 INSERT INTO skattekort_tilleggsopplysning (skattekort_id, opplysning)
@@ -178,7 +177,7 @@ object SkattekortRepository {
         tx: TransactionalSession,
         inntektsaar: Int,
     ): List<Long> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT id FROM skattekort WHERE inntektsaar = :inntektsaar ORDER BY id;
@@ -193,7 +192,7 @@ object SkattekortRepository {
         tx: TransactionalSession,
         skattekortIdList: List<Long>,
     ) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql = "DELETE FROM skattekort WHERE id = :skattekortId"
         tx.batchPreparedNamedStatement(
             sql,
@@ -204,7 +203,7 @@ object SkattekortRepository {
     }
 
     fun getSecondsSinceLatestSkattekortOpprettet(tx: TransactionalSession): Double? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql = "SELECT EXTRACT(EPOCH FROM NOW() - MAX(opprettet)) AS sekunder_siden_siste_skattekort FROM skattekort"
         return tx.single(
             queryOf(sql),
@@ -213,7 +212,7 @@ object SkattekortRepository {
     }
 
     fun numberOfSkattekortByResultatForSkattekortMetrics(tx: TransactionalSession): Map<ResultatForSkattekort, Int> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT resultatForSkattekort, COUNT(1) AS antall 
@@ -232,7 +231,7 @@ object SkattekortRepository {
     }
 
     fun numberOfForskuddstrekkWithTabelltrekkByTrekkodeMetrics(tx: TransactionalSession): Map<String, Int> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT trekk_kode, COUNT(1) AS antall 
@@ -252,7 +251,7 @@ object SkattekortRepository {
     }
 
     fun numberOfSkattekortByTilleggsopplysningMetrics(tx: TransactionalSession): Map<Tilleggsopplysning, Int> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT opplysning, COUNT(skattekort_id) AS antall 
@@ -272,7 +271,7 @@ object SkattekortRepository {
     }
 
     fun numberOfFrikortMedUtenBeloepsgrense(tx: TransactionalSession): Map<String, Int> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT 
@@ -301,7 +300,7 @@ object SkattekortRepository {
     }
 
     fun getNoekkelinformasjon(tx: TransactionalSession): Map<String, Int> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT inntektsaar::text AS key, COUNT(1) AS antall FROM skattekort GROUP BY inntektsaar

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekortbestilling/BestillingsbatchRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekortbestilling/BestillingsbatchRepository.kt
@@ -5,6 +5,7 @@ import java.time.Instant
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 object BestillingsbatchRepository {
     fun insert(
@@ -12,13 +13,16 @@ object BestillingsbatchRepository {
         bestillingsreferanse: String,
         dataSendt: String,
         type: BestillingsbatchType,
-    ): Long =
-        tx.updateAndReturnGeneratedKey(
+    ): Long {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |INSERT INTO bestillingsbatcher (bestillingsreferanse, data_sendt, type)
+                |VALUES (:bestillingsreferanse, (CAST (:dataSendt AS JSON)), :type)
+            """.trimMargin()
+        return tx.updateAndReturnGeneratedKey(
             queryOf(
-                """
-                    |INSERT INTO bestillingsbatcher (bestillingsreferanse, data_sendt, type) 
-                    |VALUES (:bestillingsreferanse, (CAST (:dataSendt AS JSON)), :type)
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "bestillingsreferanse" to bestillingsreferanse,
                     "dataSendt" to dataSendt,
@@ -26,25 +30,30 @@ object BestillingsbatchRepository {
                 ),
             ),
         ) ?: error("Failed to insert bestillingsbatch")
+    }
 
     fun getAllUnprocessedBestillingsbatch(
         tx: TransactionalSession,
         type: BestillingsbatchType,
-    ): List<Bestillingsbatch> =
-        tx.list(
+    ): List<Bestillingsbatch> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |SELECT *
+                |FROM bestillingsbatcher
+                |WHERE status IN ('${BestillingsbatchStatus.NY}', '${BestillingsbatchStatus.RETRY}') AND type = :type
+                |ORDER BY oppdatert ASC
+            """.trimMargin()
+        return tx.list(
             queryOf(
-                """
-                    |SELECT * 
-                    |FROM bestillingsbatcher
-                    |WHERE status IN ('${BestillingsbatchStatus.NY}', '${BestillingsbatchStatus.RETRY}') AND type = :type
-                    |ORDER BY oppdatert ASC
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "type" to type.name,
                 ),
             ),
             extractor = mapToBestillingsbatch,
         )
+    }
 
     fun getFilteredBestillingsbatches(
         tx: TransactionalSession,
@@ -80,32 +89,32 @@ object BestillingsbatchRepository {
     }
 
     fun getDefaultBatchInsightResults(tx: TransactionalSession): Map<Bestillingsbatch, String?> {
-        val query =
-            queryOf(
-                """
-                    |SELECT id,
-                    | status,
-                    | type,
-                    | bestillingsreferanse,
-                    | data_sendt,
-                    | oppdatert,
-                    | opprettet,
-                    | data_mottatt
-                    | 
-                    | FROM bestillingsbatcher
-                    |WHERE id IN (
-                    |        (SELECT id
-                    |            FROM bestillingsbatcher
-                    |            ORDER BY oppdatert DESC
-                    |            LIMIT 20) 
-                    |   UNION 
-                    |       (SELECT id
-                    |           FROM bestillingsbatcher
-                    |           WHERE status <> 'FERDIG')
-                    |           )
-                    |ORDER BY oppdatert DESC
-                """.trimMargin(),
-            )
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |SELECT id,
+                | status,
+                | type,
+                | bestillingsreferanse,
+                | data_sendt,
+                | oppdatert,
+                | opprettet,
+                | data_mottatt
+                |
+                | FROM bestillingsbatcher
+                |WHERE id IN (
+                |        (SELECT id
+                |            FROM bestillingsbatcher
+                |            ORDER BY oppdatert DESC
+                |            LIMIT 20)
+                |   UNION
+                |       (SELECT id
+                |           FROM bestillingsbatcher
+                |           WHERE status <> 'FERDIG')
+                |           )
+                |ORDER BY oppdatert DESC
+            """.trimMargin()
+        val query = queryOf(sql)
         return tx
             .list(
                 query,
@@ -116,38 +125,45 @@ object BestillingsbatchRepository {
     fun findById(
         tx: TransactionalSession,
         bestillingsbatchId: Long,
-    ): Bestillingsbatch? =
-        tx.single(
+    ): Bestillingsbatch? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |SELECT id,
+                | status,
+                | type,
+                | bestillingsreferanse,
+                | data_sendt,
+                | oppdatert,
+                | opprettet
+                |
+                |FROM bestillingsbatcher
+                |WHERE id = :id
+            """.trimMargin()
+        return tx.single(
             queryOf(
-                """
-                    |SELECT id,
-                    | status,
-                    | type,
-                    | bestillingsreferanse,
-                    | data_sendt,
-                    | oppdatert,
-                    | opprettet
-                    |  
-                    |FROM bestillingsbatcher
-                    |WHERE id = :id
-                """.trimMargin(),
+                sql,
                 mapOf("id" to bestillingsbatchId),
             ),
             extractor = mapToBestillingsbatch,
         )
+    }
 
     fun markAs(
         tx: TransactionalSession,
         bestillingsbatchId: Long,
         status: BestillingsbatchStatus,
     ) {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |UPDATE bestillingsbatcher
+                |SET status = :status, oppdatert = NOW()
+                |WHERE id = :id
+            """.trimMargin()
         tx.run(
             queryOf(
-                """
-                    |UPDATE bestillingsbatcher
-                    |SET status = :status, oppdatert = NOW()
-                    |WHERE id = :id
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "id" to bestillingsbatchId,
                     "status" to status.name,
@@ -161,13 +177,16 @@ object BestillingsbatchRepository {
         batchId: Long,
         dataMottatt: String,
     ) {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |UPDATE bestillingsbatcher
+                |SET data_mottatt = :dataMottatt, oppdatert = NOW()
+                |WHERE id = :id
+            """.trimMargin()
         tx.run(
             queryOf(
-                """
-                    |UPDATE bestillingsbatcher
-                    |SET data_mottatt = :dataMottatt, oppdatert = NOW()
-                    |WHERE id = :id
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "id" to batchId,
                     "dataMottatt" to dataMottatt,
@@ -176,36 +195,41 @@ object BestillingsbatchRepository {
         )
     }
 
-    fun getFirstNotFerdigBestillingsbatch(tx: TransactionalSession): Bestillingsbatch? =
-        tx.single(
-            queryOf(
-                """
-                |SELECT id,
-                | status,
-                | type,
-                | bestillingsreferanse,
-                | data_sendt,
-                | oppdatert,
-                | opprettet
-                |  
-                |FROM bestillingsbatcher WHERE status IN ('${BestillingsbatchStatus.NY}', '${BestillingsbatchStatus.RETRY}') ORDER BY opprettet LIMIT 1
-                """.trimMargin(),
-            ),
+    fun getFirstNotFerdigBestillingsbatch(tx: TransactionalSession): Bestillingsbatch? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            |SELECT id,
+            | status,
+            | type,
+            | bestillingsreferanse,
+            | data_sendt,
+            | oppdatert,
+            | opprettet
+            |
+            |FROM bestillingsbatcher WHERE status IN ('${BestillingsbatchStatus.NY}', '${BestillingsbatchStatus.RETRY}') ORDER BY opprettet LIMIT 1
+            """.trimMargin()
+        return tx.single(
+            queryOf(sql),
             extractor = mapToBestillingsbatch,
         )
+    }
 
     fun rerun(
         tx: TransactionalSession,
         id: Long,
-    ): Int =
-        tx.run(
+    ): Int {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |UPDATE bestillingsbatcher
+                |SET status = :retry, oppdatert = NOW()
+                |WHERE id = :id
+                |AND status = :feilet
+            """.trimMargin()
+        return tx.run(
             queryOf(
-                """
-                    |UPDATE bestillingsbatcher
-                    |SET status = :retry, oppdatert = NOW()
-                    |WHERE id = :id
-                    |AND status = :feilet
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "id" to id,
                     "retry" to BestillingsbatchStatus.RETRY.name,
@@ -213,29 +237,34 @@ object BestillingsbatchRepository {
                 ),
             ).asUpdate,
         )
+    }
 
-    fun getIncompleteBatches(tx: TransactionalSession): List<Bestillingsbatch> =
-        tx.list(
+    fun getIncompleteBatches(tx: TransactionalSession): List<Bestillingsbatch> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |SELECT id,
+                | status,
+                | type,
+                | bestillingsreferanse,
+                | data_sendt,
+                | oppdatert,
+                | opprettet
+                |
+                |FROM bestillingsbatcher
+                |WHERE status <> :ferdig
+                |ORDER BY oppdatert DESC
+            """.trimMargin()
+        return tx.list(
             queryOf(
-                """
-                    |SELECT id,
-                    | status,
-                    | type,
-                    | bestillingsreferanse,
-                    | data_sendt,
-                    | oppdatert,
-                    | opprettet
-                    | 
-                    |FROM bestillingsbatcher
-                    |WHERE status <> :ferdig
-                    |ORDER BY oppdatert DESC
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "ferdig" to BestillingsbatchStatus.FERDIG.name,
                 ),
             ),
             extractor = mapToBestillingsbatch,
         )
+    }
 
     val mapToBestillingsbatch: (Row) -> Bestillingsbatch = { row ->
         Bestillingsbatch(

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekortbestilling/BestillingsbatchRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekortbestilling/BestillingsbatchRepository.kt
@@ -5,7 +5,6 @@ import java.time.Instant
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 object BestillingsbatchRepository {
     fun insert(
@@ -14,7 +13,7 @@ object BestillingsbatchRepository {
         dataSendt: String,
         type: BestillingsbatchType,
     ): Long {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |INSERT INTO bestillingsbatcher (bestillingsreferanse, data_sendt, type)
@@ -36,7 +35,7 @@ object BestillingsbatchRepository {
         tx: TransactionalSession,
         type: BestillingsbatchType,
     ): List<Bestillingsbatch> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |SELECT *
@@ -89,7 +88,7 @@ object BestillingsbatchRepository {
     }
 
     fun getDefaultBatchInsightResults(tx: TransactionalSession): Map<Bestillingsbatch, String?> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |SELECT id,
@@ -126,7 +125,7 @@ object BestillingsbatchRepository {
         tx: TransactionalSession,
         bestillingsbatchId: Long,
     ): Bestillingsbatch? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |SELECT id,
@@ -154,7 +153,7 @@ object BestillingsbatchRepository {
         bestillingsbatchId: Long,
         status: BestillingsbatchStatus,
     ) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |UPDATE bestillingsbatcher
@@ -177,7 +176,7 @@ object BestillingsbatchRepository {
         batchId: Long,
         dataMottatt: String,
     ) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |UPDATE bestillingsbatcher
@@ -196,7 +195,7 @@ object BestillingsbatchRepository {
     }
 
     fun getFirstNotFerdigBestillingsbatch(tx: TransactionalSession): Bestillingsbatch? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             |SELECT id,
@@ -219,7 +218,7 @@ object BestillingsbatchRepository {
         tx: TransactionalSession,
         id: Long,
     ): Int {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |UPDATE bestillingsbatcher
@@ -240,7 +239,7 @@ object BestillingsbatchRepository {
     }
 
     fun getIncompleteBatches(tx: TransactionalSession): List<Bestillingsbatch> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |SELECT id,

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataRepository.kt
@@ -2,7 +2,6 @@ package no.nav.sokos.skattekort.skattekortdata
 
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.person.Personidentifikator
 import no.nav.sokos.skattekort.skattekort.SkattekortId
@@ -16,7 +15,7 @@ object SkattekortDataRepository {
         fnr: String,
         type: BestillingsbatchType,
     ): Long? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             INSERT INTO skattekort_data (data_mottatt, inntektsaar, fnr, type)
@@ -40,7 +39,7 @@ object SkattekortDataRepository {
         id: Long,
         skattekortId: Long,
     ) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             UPDATE skattekort_data SET skattekort_id = :skattekortId WHERE id = :id
@@ -57,7 +56,7 @@ object SkattekortDataRepository {
     }
 
     fun getUnprocessedSkattekortData(tx: TransactionalSession): List<SkattekortData> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT id, inntektsaar, data_mottatt, opprettet, fnr, skattekort_id, type FROM skattekort_data

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataRepository.kt
@@ -2,6 +2,7 @@ package no.nav.sokos.skattekort.skattekortdata
 
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.person.Personidentifikator
 import no.nav.sokos.skattekort.skattekort.SkattekortId
@@ -14,13 +15,16 @@ object SkattekortDataRepository {
         inntektsaar: Int,
         fnr: String,
         type: BestillingsbatchType,
-    ): Long? =
-        tx.run(
+    ): Long? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            INSERT INTO skattekort_data (data_mottatt, inntektsaar, fnr, type)
+            VALUES ((CAST (:dataMottatt AS JSON)), :inntektsaar, :fnr, :type)
+            """.trimIndent()
+        return tx.run(
             queryOf(
-                """
-                INSERT INTO skattekort_data (data_mottatt, inntektsaar, fnr, type)
-                VALUES ((CAST (:dataMottatt AS JSON)), :inntektsaar, :fnr, :type)
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "dataMottatt" to dataMottatt,
                     "inntektsaar" to inntektsaar,
@@ -29,17 +33,21 @@ object SkattekortDataRepository {
                 ),
             ).asUpdateAndReturnGeneratedKey,
         )
+    }
 
     fun updateSkattekortId(
         tx: TransactionalSession,
         id: Long,
         skattekortId: Long,
     ) {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            UPDATE skattekort_data SET skattekort_id = :skattekortId WHERE id = :id
+            """.trimIndent()
         tx.update(
             queryOf(
-                """
-                UPDATE skattekort_data SET skattekort_id = :skattekortId WHERE id = :id
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "skattekortId" to skattekortId,
                     "id" to id,
@@ -48,14 +56,15 @@ object SkattekortDataRepository {
         )
     }
 
-    fun getUnprocessedSkattekortData(tx: TransactionalSession): List<SkattekortData> =
-        tx.list(
-            queryOf(
-                """
-                SELECT id, inntektsaar, data_mottatt, opprettet, fnr, skattekort_id, type FROM skattekort_data 
-                WHERE skattekort_id is null
-                """.trimIndent(),
-            ),
+    fun getUnprocessedSkattekortData(tx: TransactionalSession): List<SkattekortData> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT id, inntektsaar, data_mottatt, opprettet, fnr, skattekort_id, type FROM skattekort_data
+            WHERE skattekort_id is null
+            """.trimIndent()
+        return tx.list(
+            queryOf(sql),
             extractor = { row ->
                 SkattekortData(
                     id = SkattekortDataId(row.long("id")),
@@ -68,4 +77,5 @@ object SkattekortDataRepository {
                 )
             },
         )
+    }
 }

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekorthenting/BestillingRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekorthenting/BestillingRepository.kt
@@ -5,6 +5,7 @@ import kotlin.time.toKotlinInstant
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.person.PersonId
 import no.nav.sokos.skattekort.person.Personidentifikator
@@ -14,42 +15,51 @@ object BestillingRepository {
     fun getAllBestilling(
         tx: TransactionalSession,
         maxYear: Int,
-    ): List<Bestilling> =
-        tx.list(
+    ): List<Bestilling> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT b.* FROM bestillinger b
+            WHERE b.inntektsaar <= :maxYear
+            AND b.inntektsaar = (SELECT MIN(b2.inntektsaar) FROM bestillinger b2 WHERE b2.bestillingsbatch_id IS NULL)
+            AND b.bestillingsbatch_id IS NULL
+            LIMIT 1000
+            """.trimIndent()
+        return tx.list(
             queryOf(
-                """
-                SELECT b.* FROM bestillinger b
-                WHERE b.inntektsaar <= :maxYear
-                AND b.inntektsaar = (SELECT MIN(b2.inntektsaar) FROM bestillinger b2 WHERE b2.bestillingsbatch_id IS NULL)
-                AND b.bestillingsbatch_id IS NULL
-                LIMIT 1000
-                """.trimIndent(),
+                sql,
                 mapOf("maxYear" to maxYear),
             ),
             extractor = mapToBestilling,
         )
+    }
 
-    fun getAllBestillingsForAdmin(tx: TransactionalSession): List<Bestilling> =
-        tx.list(
-            queryOf(
-                """
-                SELECT b.* FROM bestillinger b
-                """.trimIndent(),
-            ),
+    fun getAllBestillingsForAdmin(tx: TransactionalSession): List<Bestilling> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT b.* FROM bestillinger b
+            """.trimIndent()
+        return tx.list(
+            queryOf(sql),
             extractor = mapToBestilling,
         )
+    }
 
     fun insert(
         tx: TransactionalSession,
         bestilling: Bestilling,
-    ): Long? =
-        tx.updateAndReturnGeneratedKey(
+    ): Long? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+                |INSERT INTO bestillinger (person_id, inntektsaar, fnr)
+                |VALUES (:personId, :inntektsaar, :fnr)
+                |ON CONFLICT (person_id, fnr, inntektsaar) DO NOTHING
+            """.trimMargin()
+        return tx.updateAndReturnGeneratedKey(
             queryOf(
-                """
-                    |INSERT INTO bestillinger (person_id, inntektsaar, fnr) 
-                    |VALUES (:personId, :inntektsaar, :fnr) 
-                    |ON CONFLICT (person_id, fnr, inntektsaar) DO NOTHING
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "personId" to bestilling.personId.value,
                     "inntektsaar" to bestilling.inntektsaar,
@@ -57,6 +67,7 @@ object BestillingRepository {
                 ),
             ),
         )
+    }
 
     fun updateBestillingsWithBatchId(
         tx: TransactionalSession,
@@ -64,12 +75,15 @@ object BestillingRepository {
         bestillingsbatchId: Long?,
     ) {
         if (bestillingsIds.isEmpty()) return
-        tx.batchPreparedNamedStatement(
+        @Language("PostgreSQL")
+        val sql =
             """
             UPDATE bestillinger
             SET bestillingsbatch_id = :bestillingsbatchId
             WHERE id = :id
-            """.trimIndent(),
+            """.trimIndent()
+        tx.batchPreparedNamedStatement(
+            sql,
             bestillingsIds.map { mapOf("id" to it, "bestillingsbatchId" to bestillingsbatchId) },
         )
     }
@@ -78,31 +92,39 @@ object BestillingRepository {
         tx: TransactionalSession,
         fnrList: List<String>,
         batchId: Long,
-    ) = tx.batchPreparedNamedStatementAndReturnGeneratedKeys(
-        """
-        DELETE FROM bestillinger
-            WHERE bestillingsbatch_id = :bestillingsbatchId
-            AND fnr = :fnr
-        """.trimIndent(),
-        fnrList.map { fnr ->
-            mapOf(
-                "bestillingsbatchId" to batchId,
-                "fnr" to fnr,
-            )
-        },
-    )
+    ) = run {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            DELETE FROM bestillinger
+                WHERE bestillingsbatch_id = :bestillingsbatchId
+                AND fnr = :fnr
+            """.trimIndent()
+        tx.batchPreparedNamedStatementAndReturnGeneratedKeys(
+            sql,
+            fnrList.map { fnr ->
+                mapOf(
+                    "bestillingsbatchId" to batchId,
+                    "fnr" to fnr,
+                )
+            },
+        )
+    }
 
     fun findByPersonIdAndInntektsaar(
         tx: TransactionalSession,
         personId: PersonId,
         inntektsaar: Int,
-    ): Bestilling? =
-        tx.single(
+    ): Bestilling? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT * FROM bestillinger
+            WHERE person_id = :personId AND inntektsaar = :inntektsaar
+            """.trimIndent()
+        return tx.single(
             queryOf(
-                """
-                SELECT * FROM bestillinger
-                WHERE person_id = :personId AND inntektsaar = :inntektsaar
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "personId" to personId.value,
                     "inntektsaar" to inntektsaar,
@@ -110,55 +132,68 @@ object BestillingRepository {
             ),
             extractor = mapToBestilling,
         )
+    }
 
     fun getAllBestillingsInBatch(
         tx: TransactionalSession,
         batchId: Long,
-    ) = tx.list(
-        queryOf(
+    ) = run {
+        @Language("PostgreSQL")
+        val sql =
             """
             SELECT * FROM bestillinger
             WHERE bestillingsbatch_id = :bestillingsbatchId
-            """.trimIndent(),
-            mapOf(
-                "bestillingsbatchId" to batchId,
-            ),
-        ),
-        extractor = mapToBestilling,
-    )
-
-    fun getEarliestUnsentBestillingTime(tx: TransactionalSession): Double =
-        tx.single(
+            """.trimIndent()
+        tx.list(
             queryOf(
-                """
-                SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(oppdatert), NOW())) as earliest_oppdatert FROM bestillinger
-                WHERE bestillingsbatch_id IS NULL
-                """.trimIndent(),
+                sql,
+                mapOf(
+                    "bestillingsbatchId" to batchId,
+                ),
             ),
+            extractor = mapToBestilling,
+        )
+    }
+
+    fun getEarliestUnsentBestillingTime(tx: TransactionalSession): Double {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(oppdatert), NOW())) as earliest_oppdatert FROM bestillinger
+            WHERE bestillingsbatch_id IS NULL
+            """.trimIndent()
+        return tx.single(
+            queryOf(sql),
             extractor = { row -> row.double("earliest_oppdatert") },
         ) ?: error("Should always return something")
+    }
 
-    fun getEarliestSentBestillingTime(tx: TransactionalSession): Double =
-        tx.single(
-            queryOf(
-                """
-                SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(oppdatert), NOW())) as earliest_oppdatert FROM bestillinger
-                WHERE bestillingsbatch_id IS NOT NULL
-                """.trimIndent(),
-            ),
+    fun getEarliestSentBestillingTime(tx: TransactionalSession): Double {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(oppdatert), NOW())) as earliest_oppdatert FROM bestillinger
+            WHERE bestillingsbatch_id IS NOT NULL
+            """.trimIndent()
+        return tx.single(
+            queryOf(sql),
             extractor = { row -> row.double("earliest_oppdatert") },
         ) ?: error("Should always return something")
+    }
 
     fun hentResterendeBestillinger(
         tx: TransactionalSession,
         batchId: Long,
-    ): List<PersonId> =
-        tx.list(
+    ): List<PersonId> {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT person_id FROM bestillinger
+            WHERE bestillingsbatch_id = :bestillingsbatchId
+            """.trimIndent()
+        return tx.list(
             queryOf(
-                """
-                SELECT person_id FROM bestillinger
-                WHERE bestillingsbatch_id = :bestillingsbatchId
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "bestillingsbatchId" to batchId,
                 ),
@@ -167,6 +202,7 @@ object BestillingRepository {
                 PersonId(row.long("person_id"))
             },
         )
+    }
 
     val mapToBestilling: (Row) -> Bestilling = { row ->
         Bestilling(

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekorthenting/BestillingRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekorthenting/BestillingRepository.kt
@@ -5,7 +5,6 @@ import kotlin.time.toKotlinInstant
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.person.PersonId
 import no.nav.sokos.skattekort.person.Personidentifikator
@@ -16,7 +15,7 @@ object BestillingRepository {
         tx: TransactionalSession,
         maxYear: Int,
     ): List<Bestilling> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT b.* FROM bestillinger b
@@ -35,7 +34,7 @@ object BestillingRepository {
     }
 
     fun getAllBestillingsForAdmin(tx: TransactionalSession): List<Bestilling> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT b.* FROM bestillinger b
@@ -50,7 +49,7 @@ object BestillingRepository {
         tx: TransactionalSession,
         bestilling: Bestilling,
     ): Long? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
                 |INSERT INTO bestillinger (person_id, inntektsaar, fnr)
@@ -75,7 +74,7 @@ object BestillingRepository {
         bestillingsbatchId: Long?,
     ) {
         if (bestillingsIds.isEmpty()) return
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             UPDATE bestillinger
@@ -93,7 +92,7 @@ object BestillingRepository {
         fnrList: List<String>,
         batchId: Long,
     ) = run {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             DELETE FROM bestillinger
@@ -116,7 +115,7 @@ object BestillingRepository {
         personId: PersonId,
         inntektsaar: Int,
     ): Bestilling? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT * FROM bestillinger
@@ -138,7 +137,7 @@ object BestillingRepository {
         tx: TransactionalSession,
         batchId: Long,
     ) = run {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT * FROM bestillinger
@@ -156,7 +155,7 @@ object BestillingRepository {
     }
 
     fun getEarliestUnsentBestillingTime(tx: TransactionalSession): Double {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(oppdatert), NOW())) as earliest_oppdatert FROM bestillinger
@@ -169,7 +168,7 @@ object BestillingRepository {
     }
 
     fun getEarliestSentBestillingTime(tx: TransactionalSession): Double {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(oppdatert), NOW())) as earliest_oppdatert FROM bestillinger
@@ -185,7 +184,7 @@ object BestillingRepository {
         tx: TransactionalSession,
         batchId: Long,
     ): List<PersonId> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT person_id FROM bestillinger

--- a/src/main/kotlin/no/nav/sokos/skattekort/utsending/UtsendingRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/utsending/UtsendingRepository.kt
@@ -2,6 +2,7 @@ package no.nav.sokos.skattekort.utsending
 
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.forespoersel.Forsystem
 import no.nav.sokos.skattekort.person.Personidentifikator
@@ -11,14 +12,17 @@ object UtsendingRepository {
     fun insert(
         tx: TransactionalSession,
         utsending: Utsending,
-    ): Long? =
-        tx.updateAndReturnGeneratedKey(
+    ): Long? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            INSERT INTO utsendinger (fnr, inntektsaar, forsystem)
+            VALUES (:fnr, :inntektsaar, :forsystem)
+            ON CONFLICT (fnr, inntektsaar, forsystem) DO NOTHING
+            """.trimIndent()
+        return tx.updateAndReturnGeneratedKey(
             queryOf(
-                """
-                INSERT INTO utsendinger (fnr, inntektsaar, forsystem)
-                VALUES (:fnr, :inntektsaar, :forsystem)
-                ON CONFLICT (fnr, inntektsaar, forsystem) DO NOTHING
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "fnr" to utsending.fnr.value,
                     "inntektsaar" to utsending.inntektsaar,
@@ -26,26 +30,32 @@ object UtsendingRepository {
                 ),
             ),
         )
+    }
 
     fun delete(
         tx: TransactionalSession,
         id: UtsendingId,
     ) {
+        @Language("PostgreSQL")
+        val sql =
+            "DELETE FROM utsendinger WHERE id = :id".trimIndent()
         tx.update(
             queryOf(
-                """DELETE FROM utsendinger WHERE id = :id""".trimIndent(),
+                sql,
                 mapOf("id" to id.value),
             ),
         )
     }
 
-    fun getAllUtsendinger(tx: TransactionalSession): List<Utsending> =
-        tx.list(
-            queryOf(
-                """SELECT * FROM utsendinger ORDER BY ID""".trimIndent(),
-            ),
+    fun getAllUtsendinger(tx: TransactionalSession): List<Utsending> {
+        @Language("PostgreSQL")
+        val sql =
+            "SELECT * FROM utsendinger ORDER BY ID".trimIndent()
+        return tx.list(
+            queryOf(sql),
             extractor = { row -> Utsending(row) },
         )
+    }
 
     fun increaseFailCount(
         tx: TransactionalSession,
@@ -53,14 +63,17 @@ object UtsendingRepository {
         failMessage: String,
     ) {
         maybeId?.let { id ->
+            @Language("PostgreSQL")
+            val sql =
+                """
+                UPDATE utsendinger SET
+                fail_count = fail_count + 1,
+                fail_message = :fail_message
+                WHERE id = :id
+                """.trimIndent()
             tx.update(
                 queryOf(
-                    """
-                    UPDATE utsendinger SET
-                    fail_count = fail_count + 1,
-                    fail_message = :fail_message
-                    WHERE id = :id
-                    """.trimIndent(),
+                    sql,
                     mapOf(
                         "id" to id.value,
                         "fail_message" to failMessage,
@@ -75,13 +88,16 @@ object UtsendingRepository {
         fnr: Personidentifikator,
         inntektsaar: Int,
         forsystem: Forsystem,
-    ): Utsending? =
-        tx.single(
+    ): Utsending? {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT id, fnr, forsystem, inntektsaar, opprettet, fail_count, fail_message FROM utsendinger
+            WHERE fnr = :fnr AND inntektsaar = :inntektsaar AND forsystem = :forsystem
+            """.trimIndent()
+        return tx.single(
             queryOf(
-                """
-                SELECT id, fnr, forsystem, inntektsaar, opprettet, fail_count, fail_message FROM utsendinger 
-                WHERE fnr = :fnr AND inntektsaar = :inntektsaar AND forsystem = :forsystem
-                """.trimIndent(),
+                sql,
                 mapOf(
                     "fnr" to fnr.value,
                     "inntektsaar" to inntektsaar,
@@ -90,16 +106,19 @@ object UtsendingRepository {
             ),
             extractor = { row -> Utsending(row) },
         )
+    }
 
-    fun getSecondsSinceEarliestUnsentUtsending(tx: TransactionalSession): Double =
-        tx.single(
-            queryOf(
-                """
-                SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(opprettet), NOW())) as earliest_opprettet FROM utsendinger
-                """.trimIndent(),
-            ),
+    fun getSecondsSinceEarliestUnsentUtsending(tx: TransactionalSession): Double {
+        @Language("PostgreSQL")
+        val sql =
+            """
+            SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(opprettet), NOW())) as earliest_opprettet FROM utsendinger
+            """.trimIndent()
+        return tx.single(
+            queryOf(sql),
             extractor = { row -> row.double("earliest_opprettet") },
         ) ?: error("Should always return a number")
+    }
 
     fun lagreBevis(
         tx: TransactionalSession,
@@ -108,11 +127,14 @@ object UtsendingRepository {
         fnr: Personidentifikator,
         copybook: String,
     ) {
+        @Language("PostgreSQL")
+        val sql =
+            """INSERT INTO bevis_sending
+                |(skattekort_id, forsystem, fnr, sending) VALUES (:id, :forsystem, :fnr, :sending)
+            """.trimMargin()
         tx.update(
             queryOf(
-                """INSERT INTO bevis_sending
-                    |(skattekort_id, forsystem, fnr, sending) VALUES (:id, :forsystem, :fnr, :sending)
-                """.trimMargin(),
+                sql,
                 mapOf(
                     "id" to id.value,
                     "forsystem" to forsystem.value,
@@ -124,10 +146,11 @@ object UtsendingRepository {
     }
 
     fun slettGamleBevis(tx: TransactionalSession) {
+        @Language("PostgreSQL")
+        val sql =
+            "DELETE FROM bevis_sending WHERE opprettet < now() - interval '7 days'"
         tx.update(
-            queryOf(
-                """DELETE FROM bevis_sending WHERE opprettet < now() - interval '7 days'""",
-            ),
+            queryOf(sql),
         )
     }
 }

--- a/src/main/kotlin/no/nav/sokos/skattekort/utsending/UtsendingRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/utsending/UtsendingRepository.kt
@@ -2,7 +2,6 @@ package no.nav.sokos.skattekort.utsending
 
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import org.intellij.lang.annotations.Language
 
 import no.nav.sokos.skattekort.forespoersel.Forsystem
 import no.nav.sokos.skattekort.person.Personidentifikator
@@ -13,7 +12,7 @@ object UtsendingRepository {
         tx: TransactionalSession,
         utsending: Utsending,
     ): Long? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             INSERT INTO utsendinger (fnr, inntektsaar, forsystem)
@@ -36,7 +35,7 @@ object UtsendingRepository {
         tx: TransactionalSession,
         id: UtsendingId,
     ) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             "DELETE FROM utsendinger WHERE id = :id".trimIndent()
         tx.update(
@@ -48,7 +47,7 @@ object UtsendingRepository {
     }
 
     fun getAllUtsendinger(tx: TransactionalSession): List<Utsending> {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             "SELECT * FROM utsendinger ORDER BY ID".trimIndent()
         return tx.list(
@@ -63,7 +62,7 @@ object UtsendingRepository {
         failMessage: String,
     ) {
         maybeId?.let { id ->
-            @Language("PostgreSQL")
+            // language=SQL
             val sql =
                 """
                 UPDATE utsendinger SET
@@ -89,7 +88,7 @@ object UtsendingRepository {
         inntektsaar: Int,
         forsystem: Forsystem,
     ): Utsending? {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT id, fnr, forsystem, inntektsaar, opprettet, fail_count, fail_message FROM utsendinger
@@ -109,7 +108,7 @@ object UtsendingRepository {
     }
 
     fun getSecondsSinceEarliestUnsentUtsending(tx: TransactionalSession): Double {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """
             SELECT EXTRACT(EPOCH FROM NOW() - COALESCE(MIN(opprettet), NOW())) as earliest_opprettet FROM utsendinger
@@ -127,7 +126,7 @@ object UtsendingRepository {
         fnr: Personidentifikator,
         copybook: String,
     ) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             """INSERT INTO bevis_sending
                 |(skattekort_id, forsystem, fnr, sending) VALUES (:id, :forsystem, :fnr, :sending)
@@ -146,7 +145,7 @@ object UtsendingRepository {
     }
 
     fun slettGamleBevis(tx: TransactionalSession) {
-        @Language("PostgreSQL")
+        // language=SQL
         val sql =
             "DELETE FROM bevis_sending WHERE opprettet < now() - interval '7 days'"
         tx.update(


### PR DESCRIPTION
…QL")

Ekstraherer alle inline SQL-strenger til lokale variabler annotert med @Language("PostgreSQL") for å aktivere SQL-syntaksutheving og validering i IDE.

Legger til compileOnly-avhengighet for org.jetbrains:annotations:23.0.0.

----

Dette er en stooor PR med én eneste liten endring, som jeg tror gjør SQL litt mer leselig i IntelliJ. Om vi klarer å hooke opp IDE'n med et databaseskjema, så får vi også autocomplete og prediction og sånn på denne måten.