### PR TITLE
fix: return@forEach istedenfor return@transaction

### DIFF
--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataService.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataService.kt
@@ -36,9 +36,9 @@ class SkattekortDataService(
                 val skattekortData = SkattekortDataRepository.getUnprocessedSkattekortData(tx).map { data -> Triple(data.id, data.type, Json.decodeFromString<Arbeidstaker>(data.dataMottatt)) }
                 skattekortData.forEach { (id, type, arbeidstaker) ->
                     val personId =
-                        PersonRepository.findPersonIdByFnr(tx, Personidentifikator(arbeidstaker.arbeidstakeridentifikator)) ?: this.run {
+                        PersonRepository.findPersonIdByFnr(tx, Personidentifikator(arbeidstaker.arbeidstakeridentifikator)) ?: run {
                             logger.error(marker = TEAM_LOGS_MARKER) { "Fant ikke person for fnr ${arbeidstaker.arbeidstakeridentifikator}" }
-                            return@transaction
+                            return@forEach
                         }
                     val inntektsaar = arbeidstaker.inntektsaar
                     val skattekort = Skattekort(personId, arbeidstaker)

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataService.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataService.kt
@@ -33,7 +33,10 @@ class SkattekortDataService(
     fun processSkattekortData() {
         runCatching {
             dataSource.transaction { tx ->
-                val skattekortData = SkattekortDataRepository.getUnprocessedSkattekortData(tx).map { data -> Triple(data.id, data.type, Json.decodeFromString<Arbeidstaker>(data.dataMottatt)) }
+                val skattekortData =
+                    SkattekortDataRepository.getUnprocessedSkattekortData(tx)
+                        .sortedBy { it.id.value }
+                        .map { data -> Triple(data.id, data.type, Json.decodeFromString<Arbeidstaker>(data.dataMottatt)) }
                 skattekortData.forEach { (id, type, arbeidstaker) ->
                     val personId =
                         PersonRepository.findPersonIdByFnr(tx, Personidentifikator(arbeidstaker.arbeidstakeridentifikator)) ?: run {

--- a/src/test/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/skattekortdata/SkattekortDataServiceTest.kt
@@ -646,6 +646,63 @@ class SkattekortDataServiceTest :
             }
         }
 
+        test("processSkattekortData should process remaining items in batch when one FNR is unknown") {
+            // Reproduserer bug: return@transaction avbrøt hele loopen ved ukjent FNR,
+            // slik at påfølgende gyldige innslag aldri ble behandlet.
+            val unknownFnr = "99999999999"
+
+            databaseHas(
+                aPerson(1L),
+                afoedselsnummer(1L, fnr),
+                anAbonnement(1L, personId = 1L, inntektsaar = 2025),
+            )
+
+            val skattekortJson =
+                """
+                {
+                  "arbeidstakeridentifikator": "$fnr",
+                  "resultatForSkattekort": "skattekortopplysningerOK",
+                  "inntektsaar": 2025,
+                  "skattekort": {
+                    "utstedtDato": "2025-11-01",
+                    "skattekortidentifikator": 10001,
+                    "forskuddstrekk": []
+                  }
+                }
+                """.trimIndent()
+            val unknownSkattekortJson =
+                """
+                {
+                  "arbeidstakeridentifikator": "$unknownFnr",
+                  "resultatForSkattekort": "skattekortopplysningerOK",
+                  "inntektsaar": 2025,
+                  "skattekort": {
+                    "utstedtDato": "2025-11-01",
+                    "skattekortidentifikator": 20002,
+                    "forskuddstrekk": []
+                  }
+                }
+                """.trimIndent()
+
+            // Ukjent FNR legges inn FØRST — skal trigge feilhåndteringen
+            tx { SkattekortDataRepository.insert(it, unknownSkattekortJson, 2025, unknownFnr, BestillingsbatchType.BESTILLING) }
+            // Gyldig FNR legges inn ETTERPÅ — skal fortsatt bli behandlet
+            tx { SkattekortDataRepository.insert(it, skattekortJson, 2025, fnr, BestillingsbatchType.BESTILLING) }
+
+            skattekortDataService.processSkattekortData()
+
+            val skattekortList = tx { SkattekortRepository.findAllByPersonId(it, listOf(PersonId(1)), listOf(2025), adminRole = true) }
+            val utsendingList = tx(UtsendingRepository::getAllUtsendinger)
+
+            assertSoftly {
+                skattekortList shouldHaveSize 1
+                skattekortList.first().personId shouldBe PersonId(1L)
+
+                utsendingList shouldHaveSize 1
+                utsendingList.first().fnr.value shouldBe fnr
+            }
+        }
+
         test("processSkattekortData should create one utsending OS_STOR for BESTILLING and one utsending OS for OPPDATERING") {
             databaseHas(
                 aPerson(1L),


### PR DESCRIPTION
AIen sier: 
"Ved ukjent FNR avbrøt return@transaction hele transaksjons-lambdaen, slik at alle påfølgende innslag i batchen ble stiltiende ignorert. Byttet til return@forEach slik at bare det aktuelle innslaget hoppes over, og resten av batchen fortsetter å bli behandlet."

Dette forutsetter selvfølgelig at det ikke er meningen at vi skal avbryte hele jobben ved første feil. Om det er grunner til å avbryte jobben ved første feil, så bør denne PR'n slettes og glemmes.