### PR TITLE
TOB-6520 Dollybrukere kan brukes i forespørsel

### DIFF
--- a/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselService.kt
@@ -23,7 +23,6 @@ import no.nav.sokos.skattekort.skattekorthenting.BestillingRepository
 import no.nav.sokos.skattekort.util.SQLUtils.transaction
 import no.nav.sokos.skattekort.utsending.Utsending
 import no.nav.sokos.skattekort.utsending.UtsendingRepository
-import no.nav.sokos.skattekort.utsending.UtsendingService
 
 private const val DELIMITER = ";"
 private val logger = KotlinLogging.logger { }
@@ -31,7 +30,6 @@ private val logger = KotlinLogging.logger { }
 class ForespoerselService(
     private val dataSource: DataSource,
     private val personService: PersonService,
-    private val utsendingService: UtsendingService,
     private val featureToggles: UnleashIntegration,
 ) {
     fun taImotForespoersel(

--- a/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselService.kt
@@ -117,7 +117,7 @@ class ForespoerselService(
             if (skattekortList.isEmpty()) {
                 val forSentAaBestille = forSentAaBestille(forespoerselInput.inntektsaar)
                 if (forSentAaBestille) logger.warn { "Vi kan ikke lenger bestille skattekort for ${forespoerselInput.inntektsaar}" }
-                val foedselsnummerkategori = Foedselsnummerkategori.valueOf(PropertiesConfig.getApplicationProperties().gyldigeFnr)
+                val foedselsnummerkategori = Foedselsnummerkategori.valueOf(PropertiesConfig.applicationProperties.gyldigeFnr)
                 if (foedselsnummerkategori.kanBestilleSkattekort(fnr) && !forSentAaBestille && BestillingRepository.findByPersonIdAndInntektsaar(tx, personId, forespoerselInput.inntektsaar) == null) {
                     BestillingRepository.insert(
                         tx = tx,

--- a/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/forespoersel/ForespoerselService.kt
@@ -7,6 +7,7 @@ import javax.sql.DataSource
 import kotliquery.TransactionalSession
 import mu.KotlinLogging
 
+import no.nav.sokos.skattekort.config.PropertiesConfig
 import no.nav.sokos.skattekort.config.TEAM_LOGS_MARKER
 import no.nav.sokos.skattekort.infrastructure.UnleashIntegration
 import no.nav.sokos.skattekort.person.AuditRepository
@@ -22,6 +23,7 @@ import no.nav.sokos.skattekort.skattekorthenting.BestillingRepository
 import no.nav.sokos.skattekort.util.SQLUtils.transaction
 import no.nav.sokos.skattekort.utsending.Utsending
 import no.nav.sokos.skattekort.utsending.UtsendingRepository
+import no.nav.sokos.skattekort.utsending.UtsendingService
 
 private const val DELIMITER = ";"
 private val logger = KotlinLogging.logger { }
@@ -29,6 +31,7 @@ private val logger = KotlinLogging.logger { }
 class ForespoerselService(
     private val dataSource: DataSource,
     private val personService: PersonService,
+    private val utsendingService: UtsendingService,
     private val featureToggles: UnleashIntegration,
 ) {
     fun taImotForespoersel(
@@ -114,7 +117,8 @@ class ForespoerselService(
             if (skattekortList.isEmpty()) {
                 val forSentAaBestille = forSentAaBestille(forespoerselInput.inntektsaar)
                 if (forSentAaBestille) logger.warn { "Vi kan ikke lenger bestille skattekort for ${forespoerselInput.inntektsaar}" }
-                if (!forSentAaBestille && BestillingRepository.findByPersonIdAndInntektsaar(tx, personId, forespoerselInput.inntektsaar) == null) {
+                val foedselsnummerkategori = Foedselsnummerkategori.valueOf(PropertiesConfig.getApplicationProperties().gyldigeFnr)
+                if (foedselsnummerkategori.kanBestilleSkattekort(fnr) && !forSentAaBestille && BestillingRepository.findByPersonIdAndInntektsaar(tx, personId, forespoerselInput.inntektsaar) == null) {
                     BestillingRepository.insert(
                         tx = tx,
                         bestilling =

--- a/src/main/kotlin/no/nav/sokos/skattekort/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/person/PersonService.kt
@@ -148,9 +148,9 @@ class PersonService(
     fun validateFoedselsnummer(fnrList: List<String>): List<String> {
         val foedselsnummerkategori = Foedselsnummerkategori.valueOf(PropertiesConfig.getApplicationProperties().gyldigeFnr)
         return fnrList.filter { fnr ->
-            foedselsnummerkategori.kanBestilleSkattekort(fnr).also { valid ->
+            foedselsnummerkategori.erGyldig(fnr).also { valid ->
                 if (!valid) {
-                    logger.error(marker = TEAM_LOGS_MARKER) { "fjernet fnr som ikke kan bestilles fra kallet: $fnr" }
+                    logger.error(marker = TEAM_LOGS_MARKER) { "fjernet fnr som ikke er gyldig fra kallet: $fnr" }
                 }
             }
         }

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortService.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekort/SkattekortService.kt
@@ -9,6 +9,7 @@ import mu.KotlinLogging
 import no.nav.sokos.skattekort.api.model.v1.SkattekortDTO
 import no.nav.sokos.skattekort.config.PropertiesConfig
 import no.nav.sokos.skattekort.config.TEAM_LOGS_MARKER
+import no.nav.sokos.skattekort.forespoersel.AbonnementRepository
 import no.nav.sokos.skattekort.forespoersel.Foedselsnummerkategori
 import no.nav.sokos.skattekort.forespoersel.Foedselsnummerkategori.GYLDIGE
 import no.nav.sokos.skattekort.infrastructure.tilgangsmaskin.TilgangsmaskinClientService
@@ -20,6 +21,8 @@ import no.nav.sokos.skattekort.skattekort.ReglerForInntektsaar.alleLovligeInntek
 import no.nav.sokos.skattekort.util.SQLUtils.transaction
 import no.nav.sokos.skattekort.util.audit.AuditLogg
 import no.nav.sokos.skattekort.util.audit.AuditLogger
+import no.nav.sokos.skattekort.utsending.Utsending
+import no.nav.sokos.skattekort.utsending.UtsendingRepository
 import no.nav.tilgangsmaskinen.ProblemDetailResponse
 
 private val logger = KotlinLogging.logger {}
@@ -73,13 +76,13 @@ class SkattekortService(
         fnr: String,
         skattekortDTO: SkattekortDTO,
         saksbehandler: Saksbehandler?,
-    ): Long? {
+    ) {
         logger.info(marker = TEAM_LOGS_MARKER) { "Oppretter skattekort for person: $fnr, for år: ${skattekortDTO.inntektsaar}" }
 
         val foedselsnummerkategori = Foedselsnummerkategori.valueOf(PropertiesConfig.getApplicationProperties().gyldigeFnr)
         if (!foedselsnummerkategori.erGyldig(fnr)) {
             logger.warn(marker = TEAM_LOGS_MARKER) { "Ugyldig fnr for miljø ${PropertiesConfig.getApplicationProperties().environment}($fnr)" }
-            return null
+            return
         }
 
         if (GYLDIGE.erGyldig(fnr)) {
@@ -113,6 +116,16 @@ class SkattekortService(
 
             Syntetisering.evtSyntetiserSkattekort(skattekort, id)?.let { (syntetisertSkattekort, _) ->
                 SkattekortRepository.insert(tx, syntetisertSkattekort)
+            }
+            AbonnementRepository.findForsystemAndFnr(tx, personId, skattekortDTO.inntektsaar).forEach { (system, fnr) ->
+                UtsendingRepository.insert(
+                    tx,
+                    Utsending(
+                        inntektsaar = skattekortDTO.inntektsaar,
+                        fnr = fnr,
+                        forsystem = system,
+                    ),
+                )
             }
         }
     }

--- a/src/main/kotlin/no/nav/sokos/skattekort/skattekortbestilling/BestillingsbatchType.kt
+++ b/src/main/kotlin/no/nav/sokos/skattekort/skattekortbestilling/BestillingsbatchType.kt
@@ -3,4 +3,5 @@ package no.nav.sokos.skattekort.skattekortbestilling
 enum class BestillingsbatchType {
     BESTILLING,
     OPPDATERING,
+    MANUELL,
 }

--- a/src/test/kotlin/no/nav/sokos/skattekort/listener/DbListener.kt
+++ b/src/test/kotlin/no/nav/sokos/skattekort/listener/DbListener.kt
@@ -8,7 +8,6 @@ import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
 import io.kotest.extensions.testcontainers.toDataSource
 import kotliquery.queryOf
-import mu.KotlinLogging
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.ext.ScriptUtils
@@ -17,8 +16,6 @@ import org.testcontainers.jdbc.JdbcDatabaseDelegate
 import no.nav.sokos.skattekort.config.DatabaseConfig
 import no.nav.sokos.skattekort.config.PropertiesConfig
 import no.nav.sokos.skattekort.util.SQLUtils.transaction
-
-private val logger = KotlinLogging.logger {}
 
 object DbListener : BeforeSpecListener, AfterEachListener {
     private val postgresProperties = PropertiesConfig.postgresProperties


### PR DESCRIPTION
Men fnr som er ugyldige hos Skattetaten(Dolly-brukere) stoppes før man kaller Skatteetaten. Reelle stoppes forstatt i validering fordi reele brukere aldri skal sendes til test-endepunktet til Skatteetaten. 

I tillegg når man(Dolly) legger inn manuelle skattekort, sendes dette ut til alle forsystemer som abonnerer.